### PR TITLE
Derive Copy for Function Symbols.

### DIFF
--- a/crates/tamarin-sapic/src/base_translation.rs
+++ b/crates/tamarin-sapic/src/base_translation.rs
@@ -53,7 +53,7 @@ pub fn to_ln_term(t: &SapicTerm) -> LNTerm {
             match sym {
                 FunSym::Ac(o) => tamarin_term::term::f_app_ac(*o, new_args),
                 FunSym::C(o) => tamarin_term::term::f_app_c(*o, new_args),
-                FunSym::NoEq(o) => tamarin_term::term::f_app_no_eq(o.clone(), new_args),
+                FunSym::NoEq(o) => tamarin_term::term::f_app_no_eq(*o, new_args),
                 FunSym::List => tamarin_term::term::f_app_list(new_args),
             }
         }

--- a/crates/tamarin-sapic/src/let_destructors.rs
+++ b/crates/tamarin-sapic/src/let_destructors.rs
@@ -106,7 +106,7 @@ fn map_let(
         if let VTerm::App(FunSym::NoEq(funsym), rightterms) = &t2_ln {
             if funsym.constructability == Constructability::Destructor {
                 return case_destructor(
-                    rules, &t1_ln, funsym.clone(), rightterms, ann, pl, pr, elsebranch,
+                    rules, &t1_ln, *funsym, rightterms, ann, pl, pr, elsebranch,
                 );
             }
         }
@@ -205,7 +205,7 @@ fn rebuild_let_comb(
 ) -> ProcessCombinator<SapicLVar> {
     let left = ln_to_sapic(t1_ln);
     let right = ln_to_sapic(&tamarin_term::term::f_app_no_eq(
-        funsym.clone(),
+        *funsym,
         rightterms.to_vec(),
     ));
     ProcessCombinator::Let {
@@ -425,7 +425,7 @@ fn ln_to_sapic(t: &LNTerm) -> SapicTerm {
             match sym {
                 FunSym::Ac(o) => tamarin_term::term::f_app_ac(*o, new_args),
                 FunSym::C(o) => tamarin_term::term::f_app_c(*o, new_args),
-                FunSym::NoEq(o) => tamarin_term::term::f_app_no_eq(o.clone(), new_args),
+                FunSym::NoEq(o) => tamarin_term::term::f_app_no_eq(*o, new_args),
                 FunSym::List => tamarin_term::term::f_app_list(new_args),
             }
         }

--- a/crates/tamarin-sapic/src/report.rs
+++ b/crates/tamarin-sapic/src/report.rs
@@ -246,7 +246,7 @@ fn subst(loc: &Option<SapicTerm>, t: &SapicTerm) -> SapicTerm {
             match sym {
                 FunSym::Ac(o) => tamarin_term::term::f_app_ac(*o, new_args),
                 FunSym::C(o) => tamarin_term::term::f_app_c(*o, new_args),
-                FunSym::NoEq(o) => tamarin_term::term::f_app_no_eq(o.clone(), new_args),
+                FunSym::NoEq(o) => tamarin_term::term::f_app_no_eq(*o, new_args),
                 FunSym::List => tamarin_term::term::f_app_list(new_args),
             }
         }

--- a/crates/tamarin-sapic/src/typing.rs
+++ b/crates/tamarin-sapic/src/typing.rs
@@ -193,7 +193,7 @@ fn rename_term(subst: &BTreeMap<LVar, LVar>, t: &SapicTerm) -> SapicTerm {
         VTerm::App(sym, args) => {
             let new_args: Vec<SapicTerm> = args.iter().map(|a| rename_term(subst, a)).collect();
             // Rebuild through the smart constructor so AC normal form is kept.
-            tamarin_term::term::f_app(sym.clone(), new_args)
+            tamarin_term::term::f_app(*sym, new_args)
         }
     }
 }
@@ -478,7 +478,7 @@ fn type_with(
                     }
                     insert_fun(env, fs, (ptypes2, outtype2.clone()))?;
                     Ok((
-                        tamarin_term::term::f_app(sym.clone(), ts_new),
+                        tamarin_term::term::f_app(*sym, ts_new),
                         outtype2,
                     ))
                 }
@@ -490,7 +490,7 @@ fn type_with(
                         ts_new.push(a_new);
                     }
                     Ok((
-                        tamarin_term::term::f_app(sym.clone(), ts_new),
+                        tamarin_term::term::f_app(*sym, ts_new),
                         None,
                     ))
                 }
@@ -515,12 +515,12 @@ fn insert_fun(
 ) -> Result<(), String> {
     match env.funs.get(fs).cloned() {
         None => {
-            env.funs.insert(fs.clone(), new_ty);
+            env.funs.insert(*fs, new_ty);
             Ok(())
         }
         Some(old) => {
             let merged = merge_fun_types(&new_ty, &old)?;
-            env.funs.insert(fs.clone(), merged);
+            env.funs.insert(*fs, merged);
             Ok(())
         }
     }
@@ -697,7 +697,7 @@ fn init_te_from_sig(
 ) -> TypingEnvironment {
     let mut funs: BTreeMap<NoEqSym, (Vec<SapicType>, SapicType)> = BTreeMap::new();
     for fs in &maude_sig.st_fun_syms {
-        funs.insert(fs.clone(), default_function_type(fs.arity));
+        funs.insert(*fs, default_function_type(fs.arity));
     }
     // `withUserDefinedFuns`: overlay declared types onto the matching signature
     // symbol (matched by name + arity, so the BTreeMap key — the actual term
@@ -710,7 +710,7 @@ fn init_te_from_sig(
             .iter()
             .find(|fs| fs.name == name.as_bytes() && fs.arity == arity)
         {
-            funs.insert(key.clone(), (arg_types.clone(), out_type.clone()));
+            funs.insert(*key, (arg_types.clone(), out_type.clone()));
         }
     }
     TypingEnvironment { vars: BTreeMap::new(), funs }

--- a/crates/tamarin-server/src/graph/abbreviation.rs
+++ b/crates/tamarin-server/src/graph/abbreviation.rs
@@ -606,7 +606,7 @@ fn apply_proper_subterms(
             if new_args.iter().zip(args.iter()).all(|(n, o)| n == o) {
                 return t.clone();
             }
-            Term::App(s.clone(), new_args.into())
+            Term::App(*s, new_args.into())
         }
     }
 }

--- a/crates/tamarin-term/src/function_symbols.rs
+++ b/crates/tamarin-term/src/function_symbols.rs
@@ -40,7 +40,7 @@ pub enum Constructability {
 /// Free (no-equation) function symbol — name plus arity, privacy, and
 /// constructability. Mirrors the Haskell tuple
 /// `(ByteString, (Int, Privacy, Constructability))`.
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct NoEqSym {
     /// Interned into a global pool and held as a `&'static [u8]`, so a clone
     /// is a pointer copy — no heap allocation (unlike owned `Vec`) and no
@@ -80,7 +80,12 @@ impl PartialEq for NoEqSym {
     fn eq(&self, other: &Self) -> bool {
         // Destructure without `..` so a new field forces an equality decision
         // here and in the sibling Hash/Ord impls; all four fields participate.
-        let NoEqSym { name, arity, privacy, constructability } = self;
+        let NoEqSym {
+            name,
+            arity,
+            privacy,
+            constructability,
+        } = self;
         let NoEqSym {
             name: other_name,
             arity: other_arity,
@@ -106,7 +111,12 @@ impl std::hash::Hash for NoEqSym {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         // Destructure without `..` so a new field forces a hash decision here,
         // keeping this in step with Eq/Ord; all four fields are hashed.
-        let NoEqSym { name, arity, privacy, constructability } = self;
+        let NoEqSym {
+            name,
+            arity,
+            privacy,
+            constructability,
+        } = self;
         name.hash(state);
         arity.hash(state);
         privacy.hash(state);
@@ -119,7 +129,12 @@ impl Ord for NoEqSym {
         // Field order: name, arity, privacy, constructability (consistent with
         // Eq/Hash).  Only the name compare gains the ptr fast-path.  Destructure
         // without `..` so a new field forces an ordering decision here.
-        let NoEqSym { name, arity, privacy, constructability } = self;
+        let NoEqSym {
+            name,
+            arity,
+            privacy,
+            constructability,
+        } = self;
         let NoEqSym {
             name: other_name,
             arity: other_arity,
@@ -145,8 +160,18 @@ impl PartialOrd for NoEqSym {
 }
 
 impl NoEqSym {
-    pub fn new(name: impl Into<Vec<u8>>, arity: usize, privacy: Privacy, c: Constructability) -> Self {
-        NoEqSym { name: crate::intern::intern_bytes(&name.into()), arity, privacy, constructability: c }
+    pub fn new(
+        name: impl Into<Vec<u8>>,
+        arity: usize,
+        privacy: Privacy,
+        c: Constructability,
+    ) -> Self {
+        NoEqSym {
+            name: crate::intern::intern_bytes(&name.into()),
+            arity,
+            privacy,
+            constructability: c,
+        }
     }
     pub fn with_destructor(mut self) -> Self {
         self.constructability = Constructability::Destructor;
@@ -161,7 +186,7 @@ pub enum CSym {
 }
 
 /// Top-level function-symbol classification.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Copy)]
 pub enum FunSym {
     NoEq(NoEqSym),
     Ac(AcSym),
@@ -171,9 +196,15 @@ pub enum FunSym {
 }
 
 impl FunSym {
-    pub fn is_ac(&self) -> bool { matches!(self, FunSym::Ac(_)) }
-    pub fn is_c(&self) -> bool { matches!(self, FunSym::C(_)) }
-    pub fn is_list(&self) -> bool { matches!(self, FunSym::List) }
+    pub fn is_ac(&self) -> bool {
+        matches!(self, FunSym::Ac(_))
+    }
+    pub fn is_c(&self) -> bool {
+        matches!(self, FunSym::C(_))
+    }
+    pub fn is_list(&self) -> bool {
+        matches!(self, FunSym::List)
+    }
 }
 
 /// Function signature.
@@ -185,22 +216,22 @@ pub type NoEqFunSig = BTreeSet<NoEqSym>;
 // Symbol-name string constants (matching the Haskell `*SymString` family).
 // =============================================================================
 
-pub const DIFF_SYM_STRING: &[u8]     = b"diff";
-pub const MUN_SYM_STRING: &[u8]      = b"mun";
-pub const EXP_SYM_STRING: &[u8]      = b"exp";
-pub const INV_SYM_STRING: &[u8]      = b"inv";
-pub const ONE_SYM_STRING: &[u8]      = b"one";
-pub const FST_SYM_STRING: &[u8]      = b"fst";
-pub const SND_SYM_STRING: &[u8]      = b"snd";
+pub const DIFF_SYM_STRING: &[u8] = b"diff";
+pub const MUN_SYM_STRING: &[u8] = b"mun";
+pub const EXP_SYM_STRING: &[u8] = b"exp";
+pub const INV_SYM_STRING: &[u8] = b"inv";
+pub const ONE_SYM_STRING: &[u8] = b"one";
+pub const FST_SYM_STRING: &[u8] = b"fst";
+pub const SND_SYM_STRING: &[u8] = b"snd";
 pub const DH_NEUTRAL_SYM_STRING: &[u8] = b"DH_neutral";
-pub const MULT_SYM_STRING: &[u8]     = b"mult";
-pub const ZERO_SYM_STRING: &[u8]     = b"zero";
-pub const XOR_SYM_STRING: &[u8]      = b"xor";
+pub const MULT_SYM_STRING: &[u8] = b"mult";
+pub const ZERO_SYM_STRING: &[u8] = b"zero";
+pub const XOR_SYM_STRING: &[u8] = b"xor";
 pub const NAT_PLUS_SYM_STRING: &[u8] = b"tplus";
-pub const NAT_ONE_SYM_STRING: &[u8]  = b"tone";
-pub const UNION_SYM_STRING: &[u8]    = b"union";
-pub const EMAP_SYM_STRING: &[u8]     = b"em";
-pub const PMULT_SYM_STRING: &[u8]    = b"pmult";
+pub const NAT_ONE_SYM_STRING: &[u8] = b"tone";
+pub const UNION_SYM_STRING: &[u8] = b"union";
+pub const EMAP_SYM_STRING: &[u8] = b"em";
+pub const PMULT_SYM_STRING: &[u8] = b"pmult";
 
 // -- Predefined NoEq symbols --------------------------------------------------
 
@@ -211,20 +242,46 @@ fn priv_ctor(name: &[u8], arity: usize) -> NoEqSym {
     NoEqSym::new(name, arity, Privacy::Private, Constructability::Constructor)
 }
 
-pub fn pair_sym() -> NoEqSym       { pub_ctor(b"pair", 2) }
-pub fn diff_sym() -> NoEqSym       { priv_ctor(DIFF_SYM_STRING, 2) }
-pub fn exp_sym() -> NoEqSym        { pub_ctor(EXP_SYM_STRING, 2) }
-pub fn inv_sym() -> NoEqSym        { pub_ctor(INV_SYM_STRING, 1) }
-pub fn one_sym() -> NoEqSym        { pub_ctor(ONE_SYM_STRING, 0) }
-pub fn dh_neutral_sym() -> NoEqSym { pub_ctor(DH_NEUTRAL_SYM_STRING, 0) }
-pub fn fst_sym() -> NoEqSym        { pub_ctor(FST_SYM_STRING, 1) }
-pub fn snd_sym() -> NoEqSym        { pub_ctor(SND_SYM_STRING, 1) }
-pub fn pmult_sym() -> NoEqSym      { pub_ctor(PMULT_SYM_STRING, 2) }
-pub fn zero_sym() -> NoEqSym       { pub_ctor(ZERO_SYM_STRING, 0) }
-pub fn nat_one_sym() -> NoEqSym    { pub_ctor(NAT_ONE_SYM_STRING, 0) }
+pub fn pair_sym() -> NoEqSym {
+    pub_ctor(b"pair", 2)
+}
+pub fn diff_sym() -> NoEqSym {
+    priv_ctor(DIFF_SYM_STRING, 2)
+}
+pub fn exp_sym() -> NoEqSym {
+    pub_ctor(EXP_SYM_STRING, 2)
+}
+pub fn inv_sym() -> NoEqSym {
+    pub_ctor(INV_SYM_STRING, 1)
+}
+pub fn one_sym() -> NoEqSym {
+    pub_ctor(ONE_SYM_STRING, 0)
+}
+pub fn dh_neutral_sym() -> NoEqSym {
+    pub_ctor(DH_NEUTRAL_SYM_STRING, 0)
+}
+pub fn fst_sym() -> NoEqSym {
+    pub_ctor(FST_SYM_STRING, 1)
+}
+pub fn snd_sym() -> NoEqSym {
+    pub_ctor(SND_SYM_STRING, 1)
+}
+pub fn pmult_sym() -> NoEqSym {
+    pub_ctor(PMULT_SYM_STRING, 2)
+}
+pub fn zero_sym() -> NoEqSym {
+    pub_ctor(ZERO_SYM_STRING, 0)
+}
+pub fn nat_one_sym() -> NoEqSym {
+    pub_ctor(NAT_ONE_SYM_STRING, 0)
+}
 
-pub fn fst_dest_sym() -> NoEqSym { fst_sym().with_destructor() }
-pub fn snd_dest_sym() -> NoEqSym { snd_sym().with_destructor() }
+pub fn fst_dest_sym() -> NoEqSym {
+    fst_sym().with_destructor()
+}
+pub fn snd_dest_sym() -> NoEqSym {
+    snd_sym().with_destructor()
+}
 
 // -- Predefined signatures ----------------------------------------------------
 
@@ -235,15 +292,21 @@ pub fn dh_fun_sig() -> FunSig {
         FunSym::NoEq(one_sym()),
         FunSym::NoEq(inv_sym()),
         FunSym::NoEq(dh_neutral_sym()),
-    ].into_iter().collect()
+    ]
+    .into_iter()
+    .collect()
 }
 
 pub fn xor_fun_sig() -> FunSig {
-    [FunSym::Ac(AcSym::Xor), FunSym::NoEq(zero_sym())].into_iter().collect()
+    [FunSym::Ac(AcSym::Xor), FunSym::NoEq(zero_sym())]
+        .into_iter()
+        .collect()
 }
 
 pub fn bp_fun_sig() -> FunSig {
-    [FunSym::NoEq(pmult_sym()), FunSym::C(CSym::EMap)].into_iter().collect()
+    [FunSym::NoEq(pmult_sym()), FunSym::C(CSym::EMap)]
+        .into_iter()
+        .collect()
 }
 
 pub fn mset_fun_sig() -> FunSig {
@@ -255,15 +318,21 @@ pub fn pair_fun_sig() -> NoEqFunSig {
 }
 
 pub fn pair_fun_dest_sig() -> NoEqFunSig {
-    [pair_sym(), fst_dest_sym(), snd_dest_sym()].into_iter().collect()
+    [pair_sym(), fst_dest_sym(), snd_dest_sym()]
+        .into_iter()
+        .collect()
 }
 
 pub fn dh_reducible_fun_sig() -> FunSig {
-    [FunSym::NoEq(exp_sym()), FunSym::NoEq(inv_sym())].into_iter().collect()
+    [FunSym::NoEq(exp_sym()), FunSym::NoEq(inv_sym())]
+        .into_iter()
+        .collect()
 }
 
 pub fn bp_reducible_fun_sig() -> FunSig {
-    [FunSym::NoEq(pmult_sym()), FunSym::C(CSym::EMap)].into_iter().collect()
+    [FunSym::NoEq(pmult_sym()), FunSym::C(CSym::EMap)]
+        .into_iter()
+        .collect()
 }
 
 pub fn xor_reducible_fun_sig() -> FunSig {
@@ -276,11 +345,15 @@ pub fn implicit_fun_sig() -> FunSig {
         FunSym::NoEq(pair_sym()),
         FunSym::Ac(AcSym::Mult),
         FunSym::Ac(AcSym::Union),
-    ].into_iter().collect()
+    ]
+    .into_iter()
+    .collect()
 }
 
 pub fn nat_fun_sig() -> FunSig {
-    [FunSym::NoEq(nat_one_sym()), FunSym::Ac(AcSym::NatPlus)].into_iter().collect()
+    [FunSym::NoEq(nat_one_sym()), FunSym::Ac(AcSym::NatPlus)]
+        .into_iter()
+        .collect()
 }
 
 #[cfg(test)]
@@ -299,7 +372,10 @@ mod tests {
     #[test]
     fn destructors_flip_constructability() {
         assert_eq!(fst_sym().constructability, Constructability::Constructor);
-        assert_eq!(fst_dest_sym().constructability, Constructability::Destructor);
+        assert_eq!(
+            fst_dest_sym().constructability,
+            Constructability::Destructor
+        );
         // Same name though.
         assert_eq!(fst_sym().name, fst_dest_sym().name);
     }
@@ -335,16 +411,18 @@ mod tests {
     #[test]
     fn ac_sym_ord_matches_haskell_declaration() {
         assert!(AcSym::Union < AcSym::Mult);
-        assert!(AcSym::Mult  < AcSym::Xor);
-        assert!(AcSym::Xor   < AcSym::NatPlus);
+        assert!(AcSym::Mult < AcSym::Xor);
+        assert!(AcSym::Xor < AcSym::NatPlus);
     }
 
     /// FunctionSymbols.hs:97:
     ///     data Privacy = Private | Public
     #[test]
     fn privacy_ord_matches_haskell_declaration() {
-        assert!(Privacy::Private < Privacy::Public,
-                "Private MUST sort before Public — used in unifiabilty queries");
+        assert!(
+            Privacy::Private < Privacy::Public,
+            "Private MUST sort before Public — used in unifiabilty queries"
+        );
     }
 
     /// FunctionSymbols.hs:102:
@@ -364,12 +442,12 @@ mod tests {
     #[test]
     fn fun_sym_ord_matches_haskell_declaration() {
         let no_eq = FunSym::NoEq(pair_sym());
-        let ac    = FunSym::Ac(AcSym::Mult);
-        let c     = FunSym::C(CSym::EMap);
-        let list  = FunSym::List;
-        assert!(no_eq < ac,   "NoEq < AC (Haskell decl order)");
-        assert!(ac    < c,    "AC < C");
-        assert!(c     < list, "C < List");
+        let ac = FunSym::Ac(AcSym::Mult);
+        let c = FunSym::C(CSym::EMap);
+        let list = FunSym::List;
+        assert!(no_eq < ac, "NoEq < AC (Haskell decl order)");
+        assert!(ac < c, "AC < C");
+        assert!(c < list, "C < List");
         assert!(no_eq < list, "transitive: NoEq < List");
     }
 
@@ -383,13 +461,19 @@ mod tests {
         s.insert(FunSym::C(CSym::EMap));
         s.insert(FunSym::Ac(AcSym::Union));
         s.insert(FunSym::NoEq(pair_sym()));
-        let kinds: Vec<&str> = s.iter().map(|f| match f {
-            FunSym::NoEq(_) => "NoEq",
-            FunSym::Ac(_) => "AC",
-            FunSym::C(_) => "C",
-            FunSym::List => "List",
-        }).collect();
-        assert_eq!(kinds, vec!["NoEq", "AC", "C", "List"],
-                   "BTreeSet<FunSym> must iterate in Haskell decl order");
+        let kinds: Vec<&str> = s
+            .iter()
+            .map(|f| match f {
+                FunSym::NoEq(_) => "NoEq",
+                FunSym::Ac(_) => "AC",
+                FunSym::C(_) => "C",
+                FunSym::List => "List",
+            })
+            .collect();
+        assert_eq!(
+            kinds,
+            vec!["NoEq", "AC", "C", "List"],
+            "BTreeSet<FunSym> must iterate in Haskell decl order"
+        );
     }
 }

--- a/crates/tamarin-term/src/lterm.rs
+++ b/crates/tamarin-term/src/lterm.rs
@@ -563,9 +563,9 @@ where
         Term::App(fsym, args) => {
             cow_map_vec(&args[..], |a| map_free_term_cow(a, &mut *f, monotone)).map(|mapped| {
                 if monotone {
-                    crate::term::unsafe_f_app(fsym.clone(), mapped)
+                    crate::term::unsafe_f_app(*fsym, mapped)
                 } else {
-                    crate::term::f_app(fsym.clone(), mapped)
+                    crate::term::f_app(*fsym, mapped)
                 }
             })
         }

--- a/crates/tamarin-term/src/maude_proc.rs
+++ b/crates/tamarin-term/src/maude_proc.rs
@@ -1653,7 +1653,7 @@ fn unskolemize(
         }
         crate::term::Term::App(sym, args) => {
             let new_args: Vec<LNTerm> = args.iter().map(|a| unskolemize(a, reverse)).collect();
-            crate::term::Term::App(sym.clone(), new_args.into())
+            crate::term::Term::App(*sym, new_args.into())
         }
         _ => t.clone(),
     }
@@ -1701,7 +1701,7 @@ fn rewrite_skolem(
             let new_args: Vec<LNTerm> = args.iter()
                 .map(|a| rewrite_skolem(a, map))
                 .collect();
-            crate::term::Term::App(sym.clone(), new_args.into())
+            crate::term::Term::App(*sym, new_args.into())
         }
         _ => t.clone(),
     }

--- a/crates/tamarin-term/src/maude_sig.rs
+++ b/crates/tamarin-term/src/maude_sig.rs
@@ -79,7 +79,7 @@ impl MaudeSig {
         let mut all_funs: FunSig = self
             .st_fun_syms
             .iter()
-            .map(|s| FunSym::NoEq(s.clone()))
+            .map(|s| FunSym::NoEq(*s))
             .collect();
         if self.enable_dh || self.enable_bp { all_funs.extend(dh_fun_sig()); }
         if self.enable_bp { all_funs.extend(bp_fun_sig()); }
@@ -92,7 +92,7 @@ impl MaudeSig {
         let mut reducible_without_mult: FunSig = BTreeSet::new();
         for r in &self.st_rules {
             if let Term::App(o, _) = &r.lhs {
-                reducible_without_mult.insert(o.clone());
+                reducible_without_mult.insert(*o);
             }
         }
         reducible_without_mult.extend(dh_reducible_fun_sig());
@@ -105,7 +105,7 @@ impl MaudeSig {
         let mut reducible: FunSig = BTreeSet::new();
         for r in self.rrules() {
             if let Term::App(o, _) = &r.lhs {
-                reducible.insert(o.clone());
+                reducible.insert(*o);
             }
         }
 
@@ -137,7 +137,7 @@ impl MaudeSig {
     pub fn no_eq_fun_syms(&self) -> NoEqFunSig {
         self.fun_syms
             .iter()
-            .filter_map(|f| if let FunSym::NoEq(s) = f { Some(s.clone()) } else { None })
+            .filter_map(|f| if let FunSym::NoEq(s) = f { Some(*s) } else { None })
             .collect()
     }
 

--- a/crates/tamarin-term/src/maude_types.rs
+++ b/crates/tamarin-term/src/maude_types.rs
@@ -142,7 +142,7 @@ pub fn lterm_to_mterm_global(t: &LNTerm, ctx: &mut ConvCtx) -> MTerm {
             // LNTerm-side order, which (because MaudeLit Ord keys on the
             // global encounter-order id) can differ from HS's MaudeLit
             // ordering and change the emitted Maude query string.
-            crate::term::f_app(sym.clone(), new_args)
+            crate::term::f_app(*sym, new_args)
         }
     }
 }
@@ -245,7 +245,7 @@ pub fn mterm_to_lnterm(
             // constructor (and building `FunSym::C(EMap)` directly) would
             // leave `em` args in Maude's back-conversion order, producing
             // `em(XB.10, x.9)` where HS prints the sorted `em(x.9, XB.10)`.
-            crate::term::f_app(sym.clone(), new_args)
+            crate::term::f_app(*sym, new_args)
         }
     }
 }

--- a/crates/tamarin-term/src/positions.rs
+++ b/crates/tamarin-term/src/positions.rs
@@ -69,7 +69,7 @@ pub fn replace_pos<C: Ord + Clone, V: Ord + Clone>(
             if p[0] < 0 || i >= args.len() { return None; }
             let mut new = args.to_vec();
             new[i] = replace_pos(&args[i], s, &p[1..])?;
-            Some(f_app(fsym.clone(), new))
+            Some(f_app(*fsym, new))
         }
     }
 }

--- a/crates/tamarin-term/src/subst.rs
+++ b/crates/tamarin-term/src/subst.rs
@@ -219,7 +219,7 @@ fn apply_vterm_map_changed<C: Ord + Clone, V: Ord + Clone>(
             cow_map_vec(&args[..], |a| apply_vterm_map_changed(map, a)).map(|mapped| match fsym {
                 FunSym::Ac(o) => f_app_ac(*o, mapped),
                 FunSym::C(o) => f_app_c(*o, mapped),
-                FunSym::NoEq(o) => f_app_no_eq(o.clone(), mapped),
+                FunSym::NoEq(o) => f_app_no_eq(*o, mapped),
                 FunSym::List => f_app_list(mapped),
             })
         }
@@ -314,7 +314,7 @@ where
                 cow_map_vec(&args[..], |a| self.apply_changed(a)).map(|mapped| match fsym {
                     FunSym::Ac(o) => f_app_ac(*o, mapped),
                     FunSym::C(o) => f_app_c(*o, mapped),
-                    FunSym::NoEq(o) => f_app_no_eq(o.clone(), mapped),
+                    FunSym::NoEq(o) => f_app_no_eq(*o, mapped),
                     FunSym::List => f_app_list(mapped),
                 })
             }

--- a/crates/tamarin-term/src/subst_vfresh.rs
+++ b/crates/tamarin-term/src/subst_vfresh.rs
@@ -125,7 +125,7 @@ fn rename_term_drop_hint<C: Ord + Clone>(
             // (LTerm.hs:733-734).  Renaming assigns fresh idxs by first
             // appearance, so an AC/C arg list sorted under the OLD vars
             // can become unsorted under the new ones; `fApp` re-sorts.
-            crate::term::f_app(sym.clone(), new_args)
+            crate::term::f_app(*sym, new_args)
         }
     }
 }
@@ -492,7 +492,7 @@ fn rename_lvars_with_hint<C: Ord + Clone, F: FnMut(u64) -> u64>(
             // `rename_lvars_in_vterm` stays raw — it mirrors HS's
             // Monotone `unsafefApp` path under a uniform, order-
             // preserving shift, where re-sorting is unnecessary.)
-            crate::term::f_app(f.clone(), new_args)
+            crate::term::f_app(*f, new_args)
         }
     }
 }
@@ -739,7 +739,7 @@ fn rename_lvars_in_vterm<C: Clone>(
         }
         Term::Lit(other) => Term::Lit(other.clone()),
         Term::App(f, args) => Term::App(
-            f.clone(),
+            *f,
             args.iter().map(|a| rename_lvars_in_vterm(a, rename)).collect(),
         ),
     }

--- a/crates/tamarin-theory/src/constraint/solver/contradictions.rs
+++ b/crates/tamarin-theory/src/constraint/solver/contradictions.rs
@@ -453,7 +453,7 @@ fn root_sym(t: &tamarin_term::lterm::LNTerm) -> Option<RootSym> {
     use tamarin_term::term::Term;
     use tamarin_term::vterm::Lit;
     match t {
-        Term::App(sym, _) => Some(RootSym::Sym(sym.clone())),
+        Term::App(sym, _) => Some(RootSym::Sym(*sym)),
         Term::Lit(Lit::Var(v)) if v.sort == LSort::Msg => None,
         Term::Lit(Lit::Var(v)) => Some(RootSym::Sort(v.sort)),
         Term::Lit(Lit::Con(n)) => {

--- a/crates/tamarin-theory/src/constraint/solver/simplify.rs
+++ b/crates/tamarin-theory/src/constraint/solver/simplify.rs
@@ -4120,7 +4120,7 @@ fn propagate_subterm_obvious(red: &mut Reduction) -> ChangeIndicator {
             // child ti of big.  The dedupe set merges equal arms.
             Term::App(FunSym::NoEq(_), args) => {
                 let fs = match big {
-                    Term::App(fs, _) => fs.clone(),
+                    Term::App(fs, _) => *fs,
                     _ => unreachable!(),
                 };
                 if reducible.contains(&fs) { return None; }

--- a/crates/tamarin-theory/src/constraint/solver/sources.rs
+++ b/crates/tamarin-theory/src/constraint/solver/sources.rs
@@ -821,7 +821,7 @@ pub fn precompute_full_sources(
                         "t", tamarin_term::lterm::LSort::Msg, (i + 1) as u64))))
                 .collect();
             ku_patterns.push(tamarin_term::term::Term::App(
-                tamarin_term::function_symbols::FunSym::NoEq(noeq.clone()),
+                tamarin_term::function_symbols::FunSym::NoEq(*noeq),
                 args.into()));
         }
     }

--- a/crates/tamarin-theory/src/elaborate.rs
+++ b/crates/tamarin-theory/src/elaborate.rs
@@ -1882,7 +1882,7 @@ fn right_nest_pair<V>(items: Vec<VTerm<Name, V>>) -> Option<VTerm<Name, V>> {
     let mut acc = iter.next()?;
     let sym = tamarin_term::function_symbols::pair_sym();
     for prev in iter {
-        acc = f_app_no_eq(sym.clone(), vec![prev, acc]);
+        acc = f_app_no_eq(sym, vec![prev, acc]);
     }
     Some(acc)
 }

--- a/crates/tamarin-theory/src/intruder_rules.rs
+++ b/crates/tamarin-theory/src/intruder_rules.rs
@@ -647,7 +647,7 @@ pub fn construction_rules(sig: &tamarin_term::maude_sig::MaudeSig) -> Vec<IntrRu
             .map(|i| var_term(LVar::new("x", LSort::Msg, i as u64)))
             .collect();
         let prems: Vec<LNFact> = xs.iter().cloned().map(ku_fact).collect();
-        let m = f_app_no_eq(s.clone(), xs);
+        let m = f_app_no_eq(*s, xs);
         let conc = ku_fact(m.clone());
         let act = ku_fact(m);
         // Encode the constructor name in the IntrRuleACInfo.

--- a/crates/tamarin-theory/src/tools/equation_store.rs
+++ b/crates/tamarin-theory/src/tools/equation_store.rs
@@ -1412,7 +1412,7 @@ impl EquationStore {
             // Borrowing scan — entries are cloned only on match.
             for (v, t) in first.iter() {
                 let (op, args0) = match t {
-                    Term::App(o, a) => (o.clone(), a.to_vec()),
+                    Term::App(o, a) => (*o, a.to_vec()),
                     _ => continue,
                 };
                 let mut argss: Vec<Vec<LNTerm>> = vec![args0];
@@ -1459,7 +1459,7 @@ impl EquationStore {
             // Build factor `{v → op(x1, ..., xk)}`.
             let factor = LNSubst::from_list(vec![(
                 v.clone(),
-                Term::App(op.clone(),
+                Term::App(op,
                     fvars.iter()
                         .map(|fv| Term::Lit(Lit::Var(fv.clone())))
                         .collect()),
@@ -1512,7 +1512,7 @@ impl EquationStore {
             // Factor: `{v → op(fv1, fv2)}`
             let factor = LNSubst::from_list(vec![(
                 v.clone(),
-                Term::App(op.clone(), vec![
+                Term::App(op, vec![
                     Term::Lit(Lit::Var(fv1.clone())),
                     Term::Lit(Lit::Var(fv2.clone())),
                 ].into()),
@@ -1542,7 +1542,7 @@ impl EquationStore {
                         [a1, a2] => (a1.clone(), a2.clone()),
                         // `newMappings (a:as) = [(fv1,a),(fv2,fApp o as)]`
                         [a1, rest @ ..] =>
-                            (a1.clone(), Term::App(op.clone(), rest.to_vec().into())),
+                            (a1.clone(), Term::App(op, rest.to_vec().into())),
                     };
                     kept.push((fv1.clone(), a1));
                     kept.push((fv2.clone(), a_rest));

--- a/crates/tamarin-theory/src/tools/injective_fact_instances.rs
+++ b/crates/tamarin-theory/src/tools/injective_fact_instances.rs
@@ -316,7 +316,7 @@ pub fn simple_injective_fact_instances(
             Term::App(sym, args) => {
                 let mapped: Option<Vec<LNTerm>> =
                     args.iter().map(bvar_term_to_lnterm).collect();
-                mapped.map(|a| Term::App(sym.clone(), a.into()))
+                mapped.map(|a| Term::App(*sym, a.into()))
             }
         }
     }

--- a/crates/tamarin-theory/src/tools/rule_variants.rs
+++ b/crates/tamarin-theory/src/tools/rule_variants.rs
@@ -381,7 +381,7 @@ pub fn abstract_rule_and_variants(
         if let Term::App(f, args) = t {
             if irreducible.contains(f) {
                 return Term::App(
-                    f.clone(),
+                    *f,
                     args.iter().map(|a| abstr_term(a, irreducible, bindings, maude)).collect(),
                 );
             }


### PR DESCRIPTION
`NoEqSym` did not derive `Copy`, even though it could, causing `FunSym` to also not be `Copy`.

This PR derives `Copy` for both types and replaces any now unnecessary calls to `.clone()`.

I've benchmarked the change on my machine using Hyperfine on the WireGuard and GCM model and it seems to give around a 1% performance increase.

Results for proving the whole WireGuard model:

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `before` | 3.372 ± 0.022 | 3.332 | 3.436 | 1.02 ± 0.01 |
| `after` | 3.309 ± 0.019 | 3.266 | 3.352 | 1.00 |

Results for proving the whole GCM model:

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `before` | 5.850 ± 0.056 | 5.766 | 5.953 | 1.01 ± 0.01 |
| `after` | 5.818 ± 0.047 | 5.743 | 5.982 | 1.00 |

As this is a very minor change that does not affect the semantics of the code, these results/benchmarks were enough for me.

@kmilner Let me know if you want me to run any other benchmarks/tests.

PS: There is some overhead in the diff due to `Cargo fmt` on my side.