### PR TITLE
More Copy derives and Clippy

### DIFF
--- a/crates/tamarin-sapic/src/annotation.rs
+++ b/crates/tamarin-sapic/src/annotation.rs
@@ -221,7 +221,7 @@ mod tests {
         let v1 = LVar::new("a", LSort::Msg, 0);
         let v2 = LVar::new("b", LSort::Msg, 0);
         let a = ProcessAnnotation::<V>::with_lock(v1);
-        let b = ProcessAnnotation::<V>::with_lock(v2.clone());
+        let b = ProcessAnnotation::<V>::with_lock(v2);
         let c = a.append(b);
         // `AnVar` `<>` is right-biased (`(<>) _ b = b`), so combining two
         // `Just` lock annotations keeps the right (`b`) value.

--- a/crates/tamarin-sapic/src/base_translation.rs
+++ b/crates/tamarin-sapic/src/base_translation.rs
@@ -39,7 +39,7 @@ pub fn base_trans_null(p: &ProcessPosition, tildex: &BTreeSet<LVar>) -> Vec<Rule
     let st = TransFact::State(
         StateKind::LState,
         p.clone(),
-        tildex.iter().cloned().collect(),
+        tildex.iter().copied().collect(),
     );
     vec![(vec![st], vec![], vec![], vec![])]
 }
@@ -126,13 +126,13 @@ pub fn base_trans_action(
 ) -> Result<(Vec<RuleBody>, BTreeSet<LVar>), String> {
     // `def_state = State LState p tildex`
     let def_state = |tx: &BTreeSet<LVar>| {
-        TransFact::State(StateKind::LState, p.clone(), tx.iter().cloned().collect())
+        TransFact::State(StateKind::LState, p.clone(), tx.iter().copied().collect())
     };
     // `def_state' tx = State LState (p++[1]) tx`
     let mut p1 = p.clone();
     p1.push(1);
     let def_state_next = |tx: &BTreeSet<LVar>| {
-        TransFact::State(StateKind::LState, p1.clone(), tx.iter().cloned().collect())
+        TransFact::State(StateKind::LState, p1.clone(), tx.iter().copied().collect())
     };
 
     match ac {
@@ -147,7 +147,7 @@ pub fn base_trans_action(
             let semistate = TransFact::State(
                 StateKind::PSemiState,
                 p1.clone(),
-                tildex.iter().cloned().collect(),
+                tildex.iter().copied().collect(),
             );
             let body1: RuleBody = (
                 vec![def_state(tildex)],
@@ -300,7 +300,7 @@ pub fn base_trans_action(
                 let semistate = TransFact::State(
                     StateKind::LSemiState,
                     p1.clone(),
-                    tildex.iter().cloned().collect(),
+                    tildex.iter().copied().collect(),
                 );
                 let body1: RuleBody = (
                     vec![def_state(tildex)],
@@ -351,7 +351,7 @@ pub fn base_trans_action(
                 let semistate = TransFact::State(
                     StateKind::LSemiState,
                     p1.clone(),
-                    tildex.iter().cloned().collect(),
+                    tildex.iter().copied().collect(),
                 );
                 let msg_rule: RuleBody = (
                     vec![def_state(tildex)],
@@ -586,19 +586,19 @@ pub fn base_trans_comb(
 
     // `def_state = State LState p tildex`
     let def_state = |tx: &BTreeSet<LVar>| {
-        TransFact::State(StateKind::LState, p.clone(), tx.iter().cloned().collect())
+        TransFact::State(StateKind::LState, p.clone(), tx.iter().copied().collect())
     };
     // `def_state1 tx = State LState (p++[1]) tx`
     let mut p1 = p.clone();
     p1.push(1);
     let def_state1 = |tx: &BTreeSet<LVar>| {
-        TransFact::State(StateKind::LState, p1.clone(), tx.iter().cloned().collect())
+        TransFact::State(StateKind::LState, p1.clone(), tx.iter().copied().collect())
     };
     // `def_state2 tx = State LState (p++[2]) tx`
     let mut p2 = p.clone();
     p2.push(2);
     let def_state2 = |tx: &BTreeSet<LVar>| {
-        TransFact::State(StateKind::LState, p2.clone(), tx.iter().cloned().collect())
+        TransFact::State(StateKind::LState, p2.clone(), tx.iter().copied().collect())
     };
 
     match c {
@@ -631,7 +631,7 @@ pub fn base_trans_comb(
             // (untyped) Eq fact.
             let vars_f = fact_vars(&fa);
             if !vars_f.is_subset(tildex) {
-                let unbound: Vec<LVar> = vars_f.difference(tildex).cloned().collect();
+                let unbound: Vec<LVar> = vars_f.difference(tildex).copied().collect();
                 return Err(format!(
                     "process not well-formed: unbound variables in conditional: {unbound:?}"
                 ));
@@ -668,7 +668,7 @@ pub fn base_trans_comb(
             // mapped to `LVar`s to compare against `tildex :: Set LVar`.
             let freevars_f = formula_free_lvars(f);
             if !freevars_f.is_subset(tildex) {
-                let unbound: Vec<LVar> = freevars_f.difference(tildex).cloned().collect();
+                let unbound: Vec<LVar> = freevars_f.difference(tildex).copied().collect();
                 return Err(format!(
                     "process not well-formed: unbound variables in conditional: {unbound:?}"
                 ));
@@ -796,7 +796,7 @@ pub fn base_trans_comb(
                 vec![TransFact::FLet(
                     pos.clone(),
                     t2.clone(),
-                    tildex.iter().cloned().collect(),
+                    tildex.iter().copied().collect(),
                 )],
                 vec![],
             );
@@ -804,7 +804,7 @@ pub fn base_trans_comb(
                 vec![TransFact::FLet(
                     pos.clone(),
                     t1,
-                    tildex.iter().cloned().collect(),
+                    tildex.iter().copied().collect(),
                 )],
                 vec![],
                 vec![def_state1(&tildexl)],
@@ -812,7 +812,7 @@ pub fn base_trans_comb(
             );
             if an.else_branch {
                 let body2: RuleBody = (
-                    vec![TransFact::FLet(pos, t2, tildex.iter().cloned().collect())],
+                    vec![TransFact::FLet(pos, t2, tildex.iter().copied().collect())],
                     vec![],
                     vec![def_state2(tildex)],
                     vec![fa_n],

--- a/crates/tamarin-sapic/src/base_translation.rs
+++ b/crates/tamarin-sapic/src/base_translation.rs
@@ -49,8 +49,8 @@ pub fn base_trans_null(p: &ProcessPosition, tildex: &BTreeSet<LVar>) -> Vec<Rule
 /// SAPIC term to a plain `LNTerm` (drop the type tag).
 pub fn to_ln_term(t: &SapicTerm) -> LNTerm {
     match t {
-        VTerm::Lit(Lit::Var(sv)) => VTerm::Lit(Lit::Var(sv.var.clone())),
-        VTerm::Lit(Lit::Con(c)) => VTerm::Lit(Lit::Con(c.clone())),
+        VTerm::Lit(Lit::Var(sv)) => VTerm::Lit(Lit::Var(sv.var)),
+        VTerm::Lit(Lit::Con(c)) => VTerm::Lit(Lit::Con(*c)),
         VTerm::App(sym, args) => {
             let new_args: Vec<LNTerm> = args.iter().map(to_ln_term).collect();
             use tamarin_term::function_symbols::FunSym;
@@ -110,7 +110,7 @@ pub(crate) fn list_intersect<T: PartialEq + Clone>(xs: &[T], ys: &[T]) -> Vec<T>
 
 /// `toLVar v = slvar v`.
 pub fn to_lvar(v: &SapicLVar) -> LVar {
-    v.var.clone()
+    v.var
 }
 
 /// `baseTransAction` (Basetranslation.hs:94-205).  Returns the rule bodies and
@@ -168,7 +168,7 @@ pub fn base_trans_action(
         SapicAction::New(v) => {
             let lv = to_lvar(v);
             let mut tx2 = tildex.clone();
-            tx2.insert(lv.clone());
+            tx2.insert(lv);
             let body: RuleBody = (
                 vec![def_state(tildex), TransFact::Fr(lv)],
                 vec![],
@@ -204,9 +204,9 @@ pub fn base_trans_action(
         } => {
             // `x = evalFreshAvoiding (freshLVar "x" LSortMsg) tildex`.
             let x = fresh_msg_var_avoiding("x", tildex);
-            let xt: LNTerm = VTerm::Lit(Lit::Var(x.clone()));
+            let xt: LNTerm = VTerm::Lit(Lit::Var(x));
             // `xTerm = varTerm (SapicLVar { slvar = x, stype = Nothing })`.
-            let x_sapic: SapicTerm = VTerm::Lit(Lit::Var(SapicLVar::untyped(x.clone())));
+            let x_sapic: SapicTerm = VTerm::Lit(Lit::Var(SapicLVar::untyped(x)));
             // `(rules, tx', _) = baseTransComb (Let t' xTerm matchVar) (an {elseBranch=False}) p tildex`.
             let let_comb = tamarin_theory::sapic::ProcessCombinator::Let {
                 left: msg.clone(),
@@ -390,11 +390,11 @@ pub fn base_trans_action(
         //   [([def_state, CellLocked t1 (varTerm v)], [],
         //     [def_state' tx', PureCell t1 t2], [])]
         SapicAction::Insert(t1, t2) if an.pure_state && an.unlock.is_some() => {
-            let v = an.unlock.as_ref().unwrap().0.clone();
+            let v = an.unlock.as_ref().unwrap().0;
             let lt1 = to_ln_term(t1);
             let lt2 = to_ln_term(t2);
             let mut tx2 = tildex.clone();
-            tx2.insert(v.clone());
+            tx2.insert(v);
             let body: RuleBody = (
                 vec![
                     def_state(tildex),
@@ -475,14 +475,14 @@ pub fn base_trans_action(
             let Some(an_v) = &an.lock else {
                 return Err("baseTransAction: Unannotated lock".to_string());
             };
-            let v = an_v.0.clone();
+            let v = an_v.0;
             let lt = to_ln_term(t);
             let mut tx2 = tildex.clone();
-            tx2.insert(v.clone());
+            tx2.insert(v);
             let body: RuleBody = (
-                vec![def_state(tildex), TransFact::Fr(v.clone())],
+                vec![def_state(tildex), TransFact::Fr(v)],
                 vec![
-                    TransAction::LockNamed(lt.clone(), v.clone()),
+                    TransAction::LockNamed(lt.clone(), v),
                     TransAction::LockUnnamed(lt, v),
                 ],
                 vec![def_state_next(&tx2)],
@@ -498,12 +498,12 @@ pub fn base_trans_action(
             let Some(an_v) = &an.unlock else {
                 return Err("baseTransAction: Unannotated unlock".to_string());
             };
-            let v = an_v.0.clone();
+            let v = an_v.0;
             let lt = to_ln_term(t);
             let body: RuleBody = (
                 vec![def_state(tildex)],
                 vec![
-                    TransAction::UnlockNamed(lt.clone(), v.clone()),
+                    TransAction::UnlockNamed(lt.clone(), v),
                     TransAction::UnlockUnnamed(lt, v),
                 ],
                 vec![def_state_next(tildex)],
@@ -702,17 +702,17 @@ pub fn base_trans_comb(
         // (The right `IsNotSet` arm is commented out in HS — pure lookups have a
         // single arm.)
         PC::Lookup(t, v) if an.pure_state && an.unlock.is_some() => {
-            let vs = an.unlock.as_ref().unwrap().0.clone();
+            let vs = an.unlock.as_ref().unwrap().0;
             let lt = to_ln_term(t);
             let lv = to_lvar(v);
             let mut tx_prime = tildex.clone();
-            tx_prime.insert(lv.clone());
-            tx_prime.insert(vs.clone());
+            tx_prime.insert(lv);
+            tx_prime.insert(vs);
             let body: RuleBody = (
                 vec![
                     def_state(tildex),
                     TransFact::PureCell(lt.clone(), VTerm::Lit(Lit::Var(lv))),
-                    TransFact::Fr(vs.clone()),
+                    TransFact::Fr(vs),
                 ],
                 vec![],
                 vec![
@@ -732,7 +732,7 @@ pub fn base_trans_comb(
             let lt = to_ln_term(t);
             let lv = to_lvar(v);
             let mut tx_prime = tildex.clone();
-            tx_prime.insert(lv.clone());
+            tx_prime.insert(lv);
             let body_in: RuleBody = (
                 vec![def_state(tildex)],
                 vec![TransAction::IsIn(lt.clone(), lv)],

--- a/crates/tamarin-sapic/src/compression.rs
+++ b/crates/tamarin-sapic/src/compression.rs
@@ -127,7 +127,7 @@ fn merge_attrs(a: RuleAttributes, b: RuleAttributes) -> RuleAttributes {
 /// `mergeInfo` (Compression.hs:60-68): keep the FIRST rule's name, merge attrs,
 /// concatenate restrictions.
 fn merge_info(i1: &ProtoRuleEInfo, i2: &ProtoRuleEInfo) -> ProtoRuleEInfo {
-    let name = i1.name.clone(); // `mergeStand n _ = n`
+    let name = i1.name; // `mergeStand n _ = n`
     let attributes = merge_attrs(i1.attributes.clone(), i2.attributes.clone());
     let mut restrictions = i1.restrictions.clone();
     restrictions.extend(i2.restrictions.clone());

--- a/crates/tamarin-sapic/src/facts.rs
+++ b/crates/tamarin-sapic/src/facts.rs
@@ -171,7 +171,7 @@ fn sorted_unique(mut vs: Vec<LVar>) -> Vec<LVar> {
 /// `factToFact` (Facts.hs:253-271).
 pub fn fact_to_fact(f: &TransFact) -> LNFact {
     match f {
-        TransFact::Fr(v) => fresh_fact(VTerm::Lit(Lit::Var(v.clone()))),
+        TransFact::Fr(v) => fresh_fact(VTerm::Lit(Lit::Var(*v))),
         TransFact::In(t) => in_fact(t.clone()),
         TransFact::Out(t) => out_fact(t.clone()),
         TransFact::State(kind, p, vars) => {
@@ -261,7 +261,7 @@ pub fn action_to_fact(a: &TransAction) -> LNFact {
         TransAction::IsIn(t, v) => proto_fact(
             Multiplicity::Linear,
             "IsIn",
-            vec![t.clone(), VTerm::Lit(Lit::Var(v.clone()))],
+            vec![t.clone(), VTerm::Lit(Lit::Var(*v))],
         ),
         // `actionToFact (IsNotSet t) = protoFact Linear "IsNotSet" [t]` (Facts.hs:213-234, see line 221).
         TransAction::IsNotSet(t) => proto_fact(Multiplicity::Linear, "IsNotSet", vec![t.clone()]),
@@ -278,14 +278,14 @@ pub fn action_to_fact(a: &TransAction) -> LNFact {
         TransAction::LockNamed(t, v) => proto_fact(
             Multiplicity::Linear,
             &lock_fact_name(v),
-            vec![lock_pub_term(v), VTerm::Lit(Lit::Var(v.clone())), t.clone()],
+            vec![lock_pub_term(v), VTerm::Lit(Lit::Var(*v)), t.clone()],
         ),
         // `actionToFact (LockUnnamed t v) =
         //    protoFact Linear "Lock" [lockPubTerm v, varTerm v, t]` (Facts.hs:213-234, see line 229).
         TransAction::LockUnnamed(t, v) => proto_fact(
             Multiplicity::Linear,
             "Lock",
-            vec![lock_pub_term(v), VTerm::Lit(Lit::Var(v.clone())), t.clone()],
+            vec![lock_pub_term(v), VTerm::Lit(Lit::Var(*v)), t.clone()],
         ),
         // `actionToFact (UnlockNamed t v) =
         //    protoFact Linear (unlockFactName v) [lockPubTerm v, varTerm v, t]`
@@ -293,14 +293,14 @@ pub fn action_to_fact(a: &TransAction) -> LNFact {
         TransAction::UnlockNamed(t, v) => proto_fact(
             Multiplicity::Linear,
             &unlock_fact_name(v),
-            vec![lock_pub_term(v), VTerm::Lit(Lit::Var(v.clone())), t.clone()],
+            vec![lock_pub_term(v), VTerm::Lit(Lit::Var(*v)), t.clone()],
         ),
         // `actionToFact (UnlockUnnamed t v) =
         //    protoFact Linear "Unlock" [lockPubTerm v, varTerm v, t]` (Facts.hs:213-234, see line 231).
         TransAction::UnlockUnnamed(t, v) => proto_fact(
             Multiplicity::Linear,
             "Unlock",
-            vec![lock_pub_term(v), VTerm::Lit(Lit::Var(v.clone())), t.clone()],
+            vec![lock_pub_term(v), VTerm::Lit(Lit::Var(*v)), t.clone()],
         ),
         // `actionToFact (ChannelIn t) = protoFact Linear "ChannelIn" [t]`
         // (Facts.hs:213-234, see line 224).
@@ -387,7 +387,7 @@ pub fn add_var_to_state(v: &LVar, f: &TransFact) -> TransFact {
         TransFact::State(kind, pos, vs) => {
             let mut nvs = vs.clone();
             if !nvs.contains(v) {
-                nvs.push(v.clone());
+                nvs.push(*v);
             }
             TransFact::State(*kind, pos.clone(), nvs)
         }
@@ -421,7 +421,7 @@ fn map_fact_name(f: &LNFact, prefix: &str) -> LNFact {
             tamarin_term::intern::intern_str(&format!("{prefix}{s}")),
             *i,
         ),
-        other => other.clone(),
+        other => *other,
     };
     tamarin_theory::fact::Fact::new(tag, f.terms.to_vec()).with_annotations(f.annotations.clone())
 }
@@ -637,7 +637,7 @@ pub fn compute_new_vars(prems: &[LNFact], concs: &[LNFact], acts: &[LNFact]) -> 
     fn collect(t: &LNTerm, out: &mut BTreeSet<LVar>) {
         match t {
             VTerm::Lit(Lit::Var(v)) => {
-                out.insert(v.clone());
+                out.insert(*v);
             }
             VTerm::Lit(_) => {}
             VTerm::App(_, args) => {

--- a/crates/tamarin-sapic/src/inline.rs
+++ b/crates/tamarin-sapic/src/inline.rs
@@ -145,7 +145,7 @@ fn inline_call(
     for (param, arg) in params.iter().zip(sapic_args.iter()) {
         pairs.push((param.clone(), arg.clone()));
         if param.stype.is_some() {
-            pairs.push((SapicLVar::untyped(param.var.clone()), arg.clone()));
+            pairs.push((SapicLVar::untyped(param.var), arg.clone()));
         }
     }
     let subst = SapicSubst::from_list(pairs);
@@ -211,7 +211,7 @@ fn apply_m_process(subst: &SapicSubst, p: PlainProcess) -> Result<PlainProcess, 
 /// True iff a substitution maps `v` (in either typed or untyped form) — i.e.
 /// `v ∈ dom subst`, used for the capture checks.
 fn in_domain(subst: &SapicSubst, v: &SapicLVar) -> bool {
-    subst.image_of(v).is_some() || subst.image_of(&SapicLVar::untyped(v.var.clone())).is_some()
+    subst.image_of(v).is_some() || subst.image_of(&SapicLVar::untyped(v.var)).is_some()
 }
 
 /// `applyM` for `SapicAction` (Process.hs:392-408): substitute terms, raising
@@ -357,7 +357,7 @@ fn apply_match_vars(
     for v in vs {
         let img = subst
             .image_of(v)
-            .or_else(|| subst.image_of(&SapicLVar::untyped(v.var.clone())));
+            .or_else(|| subst.image_of(&SapicLVar::untyped(v.var)));
         match img {
             Some(t) => {
                 for w in tamarin_term::vterm::vars_vterm_in_order(t) {

--- a/crates/tamarin-sapic/src/let_destructors.rs
+++ b/crates/tamarin-sapic/src/let_destructors.rs
@@ -242,7 +242,7 @@ fn find_rule(
         if let VTerm::App(FunSym::NoEq(fs), y) = &rr.lhs {
             if let VTerm::Lit(Lit::Var(v)) = &rr.rhs {
                 if fs == funsym {
-                    acc = Some((y.to_vec(), v.clone()));
+                    acc = Some((y.to_vec(), *v));
                 }
             }
         }
@@ -271,7 +271,7 @@ fn to_pairs(ts: &[LNTerm]) -> LNTerm {
 fn make_let_subst(svar: &SapicLVar, t2: &SapicTerm) -> Subst<Name, SapicLVar> {
     let mut pairs: Vec<(SapicLVar, SapicTerm)> = vec![(svar.clone(), t2.clone())];
     if svar.stype.is_some() {
-        pairs.push((SapicLVar::untyped(svar.var.clone()), t2.clone()));
+        pairs.push((SapicLVar::untyped(svar.var), t2.clone()));
     }
     Subst::from_list(pairs)
 }
@@ -429,8 +429,8 @@ fn subst_cond_formula(
         // was typed, its typed variant too); a `Cond`-formula var is untyped, so
         // probe the untyped key first, then the typed-erased path.
         let img = subst
-            .image_of(&SapicLVar::untyped(lv.clone()))
-            .or_else(|| subst.image_of(&SapicLVar::new(lv.clone(), None)));
+            .image_of(&SapicLVar::untyped(lv))
+            .or_else(|| subst.image_of(&SapicLVar::new(lv, None)));
         img.map(|t| {
             crate::base_translation::ln_term_to_parser(&crate::base_translation::to_ln_term(t))
         })
@@ -440,8 +440,8 @@ fn subst_cond_formula(
 /// Lift an `LNTerm` (untyped) back to a SAPIC term (all variables untyped).
 fn ln_to_sapic(t: &LNTerm) -> SapicTerm {
     match t {
-        VTerm::Lit(Lit::Var(v)) => VTerm::Lit(Lit::Var(SapicLVar::untyped(v.clone()))),
-        VTerm::Lit(Lit::Con(c)) => VTerm::Lit(Lit::Con(c.clone())),
+        VTerm::Lit(Lit::Var(v)) => VTerm::Lit(Lit::Var(SapicLVar::untyped(*v))),
+        VTerm::Lit(Lit::Con(c)) => VTerm::Lit(Lit::Con(*c)),
         VTerm::App(sym, args) => {
             let new_args: Vec<SapicTerm> = args.iter().map(ln_to_sapic).collect();
             match sym {

--- a/crates/tamarin-sapic/src/locks.rs
+++ b/crates/tamarin-sapic/src/locks.rs
@@ -57,14 +57,14 @@ fn annotate_each_closest_unlock(
             // (Unlock t') | t == t' -> annUnlock here, STOP (closest match).
             //              | otherwise -> recurse into body.
             SapicAction::Unlock(t_prime) if t == t_prime => {
-                let a2 = a.append(ProcessAnnotation::with_unlock(v.clone()));
+                let a2 = a.append(ProcessAnnotation::with_unlock(*v));
                 Ok(Process::Action(ac, a2, body))
             }
             // (Insert t1 t2) | t1 == t -> annUnlock here AND recurse into body.
             //  (otherwise falls through to the generic action case below.)
             SapicAction::Insert(t1, _t2) if t1 == t => {
                 let body2 = annotate_each_closest_unlock(t, v, *body)?;
-                let a2 = a.append(ProcessAnnotation::with_unlock(v.clone()));
+                let a2 = a.append(ProcessAnnotation::with_unlock(*v));
                 Ok(Process::Action(ac, a2, Box::new(body2)))
             }
             // (Rep) -> Left WFRep
@@ -82,7 +82,7 @@ fn annotate_each_closest_unlock(
             ProcessCombinator::Lookup(st, _vt) if st == t => {
                 let pl2 = annotate_each_closest_unlock(t, v, *pl)?;
                 let pr2 = annotate_each_closest_unlock(t, v, *pr)?;
-                let a2 = a.append(ProcessAnnotation::with_unlock(v.clone()));
+                let a2 = a.append(ProcessAnnotation::with_unlock(*v));
                 Ok(Process::Comb(c, a2, Box::new(pl2), Box::new(pr2)))
             }
             // generic combinator: recurse into both children (no annotation).

--- a/crates/tamarin-sapic/src/progress_translation.rs
+++ b/crates/tamarin-sapic/src/progress_translation.rs
@@ -54,7 +54,7 @@ fn add_progress_from(dom_pf: &PosSet, child: &[i64], body: RuleBody) -> RuleBody
     let any_non_semi = r.iter().any(is_non_semi_state);
     if any_non_semi && dom_pf.contains(child) {
         let vp = var_progress(&child.to_vec());
-        let mut nl = vec![TransFact::Fr(vp.clone())];
+        let mut nl = vec![TransFact::Fr(vp)];
         nl.extend(l);
         let mut na = vec![TransAction::ProgressFrom(child.to_vec())];
         na.extend(a);

--- a/crates/tamarin-sapic/src/reliable_channel.rs
+++ b/crates/tamarin-sapic/src/reliable_channel.rs
@@ -80,11 +80,11 @@ pub fn reliable_channel_trans_act(
     tx: &BTreeSet<LVar>,
 ) -> Result<Option<(Vec<RuleBody>, BTreeSet<LVar>)>, String> {
     // `def_state = State LState p tx`; `def_state1 tx' = State LState (p++[1]) tx'`.
-    let def_state = || TransFact::State(StateKind::LState, p.clone(), tx.iter().cloned().collect());
+    let def_state = || TransFact::State(StateKind::LState, p.clone(), tx.iter().copied().collect());
     let mut p1 = p.clone();
     p1.push(1);
     let def_state1 = |tx2: &BTreeSet<LVar>| {
-        TransFact::State(StateKind::LState, p1.clone(), tx2.iter().cloned().collect())
+        TransFact::State(StateKind::LState, p1.clone(), tx2.iter().copied().collect())
     };
 
     match ac {

--- a/crates/tamarin-sapic/src/report.rs
+++ b/crates/tamarin-sapic/src/report.rs
@@ -60,8 +60,8 @@ pub fn report_init(
     // `x`, `loc` :: LVar _ LSortMsg 0.
     let x = LVar::new("x", LSort::Msg, 0);
     let loc = LVar::new("loc", LSort::Msg, 0);
-    let xt: LNTerm = VTerm::Lit(Lit::Var(x.clone()));
-    let loct: LNTerm = VTerm::Lit(Lit::Var(loc.clone()));
+    let xt: LNTerm = VTerm::Lit(Lit::Var(x));
+    let loct: LNTerm = VTerm::Lit(Lit::Var(loc));
 
     // prem: In( <x, loc> )
     let prem = TransFact::In(tamarin_term::builtin::pair(xt.clone(), loct.clone()));

--- a/crates/tamarin-sapic/src/secret_channels.rs
+++ b/crates/tamarin-sapic/src/secret_channels.rs
@@ -35,7 +35,7 @@ fn get_secret_channels(p: &AnnotatedProc, candidates: BTreeSet<LVar>) -> BTreeSe
     match p {
         Process::Action(SapicAction::New(v), _, body) => {
             let mut next = candidates;
-            next.insert(v.var.clone());
+            next.insert(v.var);
             get_secret_channels(body, next)
         }
         Process::Action(SapicAction::ChOut { msg, .. }, _, body)
@@ -102,7 +102,7 @@ fn lit_var(t: &SapicTerm) -> Option<LVar> {
     use tamarin_term::term::Term;
     use tamarin_term::vterm::Lit;
     match t {
-        Term::Lit(Lit::Var(sv)) => Some(sv.var.clone()),
+        Term::Lit(Lit::Var(sv)) => Some(sv.var),
         _ => None,
     }
 }

--- a/crates/tamarin-sapic/src/secret_channels.rs
+++ b/crates/tamarin-sapic/src/secret_channels.rs
@@ -50,7 +50,7 @@ fn get_secret_channels(p: &AnnotatedProc, candidates: BTreeSet<LVar>) -> BTreeSe
         Process::Comb(_, _, l, r) => {
             let cl = get_secret_channels(l, candidates.clone());
             let cr = get_secret_channels(r, candidates);
-            cl.intersection(&cr).cloned().collect()
+            cl.intersection(&cr).copied().collect()
         }
     }
 }

--- a/crates/tamarin-sapic/src/states.rs
+++ b/crates/tamarin-sapic/src/states.rs
@@ -77,7 +77,7 @@ fn get_all_states(
         // New v: extend the bound-name scope.
         Process::Action(SapicAction::New(v), _, body) => {
             let mut next = bound_names.clone();
-            next.insert(v.var.clone());
+            next.insert(v.var);
             get_all_states(body, &next)
         }
         Process::Action(_, _, body) => get_all_states(body, bound_names),
@@ -150,7 +150,7 @@ fn declare_state_channel(
     state_map: &StateMap,
 ) -> AnnotatedProc {
     // `(declarables, undeclarables) = partition (frees ⊆ boundNames) toDeclare`
-    let bound_lvars: BTreeSet<LVar> = bound_names.iter().map(|v| v.var.clone()).collect();
+    let bound_lvars: BTreeSet<LVar> = bound_names.iter().map(|v| v.var).collect();
     let (declarables, undeclarables): (Vec<SapicTerm>, Vec<SapicTerm>) =
         to_declare.iter().cloned().partition(|t| {
             frees_sapic_term(t)
@@ -221,7 +221,7 @@ fn add_news(pr: AnnotatedProc, new_vars: &[(LVar, SapicTerm)]) -> AnnotatedProc 
             ..ProcessAnnotation::empty()
         };
         out = Process::Action(
-            SapicAction::New(SapicLVar::new(var.clone(), Some("channel".to_string()))),
+            SapicAction::New(SapicLVar::new(*var, Some("channel".to_string()))),
             ann,
             Box::new(out),
         );
@@ -248,7 +248,7 @@ fn new_states(
             sort: LSort::Msg,
             idx: fresh.fresh_ident(),
         };
-        map.insert(v.clone(), AnVar(newvar.clone()));
+        map.insert(v.clone(), AnVar(newvar));
         // HS conses: `newStates p declarables ((newvar, v):declared) newMap`
         declared.insert(0, (newvar, v.clone()));
     }
@@ -263,7 +263,7 @@ fn exists_attacker_unpure(p: &AnnotatedProc, bound_names: &BTreeSet<LVar>) -> bo
         // New v: extend the bound-name scope.
         Process::Action(SapicAction::New(v), _, pl) => {
             let mut next = bound_names.clone();
-            next.insert(v.var.clone());
+            next.insert(v.var);
             exists_attacker_unpure(pl, &next)
         }
         // insert t; unlock t  (pure write pattern) — skip the pair, recurse.
@@ -487,7 +487,7 @@ fn vars_proc(p: &AnnotatedProc) -> Vec<LVar> {
             Process::Action(a, _, body) => {
                 match a {
                     SapicAction::New(v) => {
-                        out.insert(v.var.clone());
+                        out.insert(v.var);
                     }
                     SapicAction::Event(f) => fact_vars(f, out),
                     SapicAction::ChOut { chan, msg } => {
@@ -506,7 +506,7 @@ fn vars_proc(p: &AnnotatedProc) -> Vec<LVar> {
                         }
                         term_vars(msg, out);
                         for v in match_vars {
-                            out.insert(v.var.clone());
+                            out.insert(v.var);
                         }
                     }
                     SapicAction::Insert(a, b) => {
@@ -536,7 +536,7 @@ fn vars_proc(p: &AnnotatedProc) -> Vec<LVar> {
                 match c {
                     ProcessCombinator::Lookup(t, v) => {
                         term_vars(t, out);
-                        out.insert(v.var.clone());
+                        out.insert(v.var);
                     }
                     ProcessCombinator::Let {
                         left,
@@ -546,7 +546,7 @@ fn vars_proc(p: &AnnotatedProc) -> Vec<LVar> {
                         term_vars(left, out);
                         term_vars(right, out);
                         for v in match_vars {
-                            out.insert(v.var.clone());
+                            out.insert(v.var);
                         }
                     }
                     ProcessCombinator::CondEq(a, b) => {

--- a/crates/tamarin-sapic/src/translate.rs
+++ b/crates/tamarin-sapic/src/translate.rs
@@ -303,7 +303,7 @@ fn get_lock_positions(p: &Process<ProcessAnnotation<LVar>, SapicLVar>) -> Vec<LV
         if let Process::Action(SapicAction::Lock(_), an, _) = proc {
             if !an.pure_state {
                 if let Some(v) = &an.lock {
-                    return vec![v.0.clone()];
+                    return vec![v.0];
                 }
             }
         }
@@ -321,7 +321,7 @@ fn get_unlock_positions(p: &Process<ProcessAnnotation<LVar>, SapicLVar>) -> Vec<
         if let Process::Action(SapicAction::Unlock(_), an, _) = proc {
             if !an.pure_state {
                 if let Some(v) = &an.unlock {
-                    return vec![v.0.clone()];
+                    return vec![v.0];
                 }
             }
         }

--- a/crates/tamarin-sapic/src/typing.rs
+++ b/crates/tamarin-sapic/src/typing.rs
@@ -206,7 +206,7 @@ fn rename_cond_formula(
 fn rename_term(subst: &BTreeMap<LVar, LVar>, t: &SapicTerm) -> SapicTerm {
     match t {
         VTerm::Lit(Lit::Var(sv)) => {
-            let new_lv = subst.get(&sv.var).cloned().unwrap_or(sv.var);
+            let new_lv = subst.get(&sv.var).copied().unwrap_or(sv.var);
             VTerm::Lit(Lit::Var(SapicLVar::new(new_lv, sv.stype.clone())))
         }
         VTerm::Lit(Lit::Con(c)) => VTerm::Lit(Lit::Con(*c)),
@@ -219,7 +219,7 @@ fn rename_term(subst: &BTreeMap<LVar, LVar>, t: &SapicTerm) -> SapicTerm {
 }
 
 fn rename_sv(subst: &BTreeMap<LVar, LVar>, sv: &SapicLVar) -> SapicLVar {
-    let new_lv = subst.get(&sv.var).cloned().unwrap_or(sv.var);
+    let new_lv = subst.get(&sv.var).copied().unwrap_or(sv.var);
     SapicLVar::new(new_lv, sv.stype.clone())
 }
 

--- a/crates/tamarin-sapic/src/typing.rs
+++ b/crates/tamarin-sapic/src/typing.rs
@@ -206,13 +206,10 @@ fn rename_cond_formula(
 fn rename_term(subst: &BTreeMap<LVar, LVar>, t: &SapicTerm) -> SapicTerm {
     match t {
         VTerm::Lit(Lit::Var(sv)) => {
-            let new_lv = subst
-                .get(&sv.var)
-                .cloned()
-                .unwrap_or_else(|| sv.var.clone());
+            let new_lv = subst.get(&sv.var).cloned().unwrap_or(sv.var);
             VTerm::Lit(Lit::Var(SapicLVar::new(new_lv, sv.stype.clone())))
         }
-        VTerm::Lit(Lit::Con(c)) => VTerm::Lit(Lit::Con(c.clone())),
+        VTerm::Lit(Lit::Con(c)) => VTerm::Lit(Lit::Con(*c)),
         VTerm::App(sym, args) => {
             let new_args: Vec<SapicTerm> = args.iter().map(|a| rename_term(subst, a)).collect();
             // Rebuild through the smart constructor so AC normal form is kept.
@@ -222,10 +219,7 @@ fn rename_term(subst: &BTreeMap<LVar, LVar>, t: &SapicTerm) -> SapicTerm {
 }
 
 fn rename_sv(subst: &BTreeMap<LVar, LVar>, sv: &SapicLVar) -> SapicLVar {
-    let new_lv = subst
-        .get(&sv.var)
-        .cloned()
-        .unwrap_or_else(|| sv.var.clone());
+    let new_lv = subst.get(&sv.var).cloned().unwrap_or(sv.var);
     SapicLVar::new(new_lv, sv.stype.clone())
 }
 
@@ -380,8 +374,8 @@ fn mk_subst(
     for sv in bvars {
         let lv = &sv.var;
         let v_new = tamarin_term::lterm::fresh_lvar(fresh, lv.name, lv.sort);
-        fwd.insert(lv.clone(), v_new.clone());
-        inv_pairs.push((v_new, VTerm::Lit(Lit::Var(lv.clone()))));
+        fwd.insert(*lv, v_new);
+        inv_pairs.push((v_new, VTerm::Lit(Lit::Var(*lv))));
     }
     let inv = tamarin_term::subst::Subst::from_list(inv_pairs);
     (fwd, inv)
@@ -477,9 +471,9 @@ fn type_with(
                 }
             };
             let merged = sqcap(&stype, tt)?;
-            env.vars.insert(lvar.clone(), merged.clone());
+            env.vars.insert(*lvar, merged.clone());
             Ok((
-                VTerm::Lit(Lit::Var(SapicLVar::new(lvar.clone(), merged.clone()))),
+                VTerm::Lit(Lit::Var(SapicLVar::new(*lvar, merged.clone()))),
                 merged,
             ))
         }
@@ -624,7 +618,7 @@ fn insert_var(env: &mut TypingEnvironment, v: &SapicLVar) -> Result<(), String> 
     if env.vars.contains_key(&v.var) {
         return Err(format!("variable bound twice: {:?}", v.var));
     }
-    env.vars.insert(v.var.clone(), v.stype.clone());
+    env.vars.insert(v.var, v.stype.clone());
     Ok(())
 }
 
@@ -632,7 +626,7 @@ fn insert_var(env: &mut TypingEnvironment, v: &SapicLVar) -> Result<(), String> 
 /// correctly typed; if untyped, give it `defaultSapicType` (= `Nothing`).
 fn type_with_var(v: &SapicLVar) -> SapicLVar {
     match &v.stype {
-        None => SapicLVar::new(v.var.clone(), None),
+        None => SapicLVar::new(v.var, None),
         Some(_) => v.clone(),
     }
 }

--- a/crates/tamarin-server/src/graph/repr.rs
+++ b/crates/tamarin-server/src/graph/repr.rs
@@ -193,29 +193,29 @@ pub fn find_connected_components<'a>(
     let mut adj: BTreeMap<NodeId, BTreeSet<NodeId>> = BTreeMap::new();
     for e in edges {
         if let GEdge::System(s, t) = e {
-            let (a, b) = (s.0.clone(), t.0.clone());
-            adj.entry(a.clone()).or_default().insert(b.clone());
+            let (a, b) = (s.0, t.0);
+            adj.entry(a).or_default().insert(b);
             adj.entry(b).or_default().insert(a);
         }
     }
     let mut visited: BTreeSet<NodeId> = BTreeSet::new();
     let mut components: Vec<Vec<&'a GNode>> = Vec::new();
-    let by_id: BTreeSet<NodeId> = nodes.iter().map(|n| n.id.clone()).collect();
+    let by_id: BTreeSet<NodeId> = nodes.iter().map(|n| n.id).collect();
     for n in nodes {
         if visited.contains(&n.id) {
             continue;
         }
-        let mut stack = vec![n.id.clone()];
+        let mut stack = vec![n.id];
         let mut comp_set: BTreeSet<NodeId> = BTreeSet::new();
         while let Some(cur) = stack.pop() {
-            if !visited.insert(cur.clone()) {
+            if !visited.insert(cur) {
                 continue;
             }
-            comp_set.insert(cur.clone());
+            comp_set.insert(cur);
             if let Some(neighbors) = adj.get(&cur) {
                 for nb in neighbors {
                     if !visited.contains(nb) && by_id.contains(nb) {
-                        stack.push(nb.clone());
+                        stack.push(*nb);
                     }
                 }
             }
@@ -257,11 +257,11 @@ pub fn add_cluster(
     let all_edges = repr.edges.clone();
     let mut sub_clusters: Vec<Cluster> = Vec::new();
     for (group_name, group_nodes) in &nodes_by_group {
-        let group_node_ids: BTreeSet<NodeId> = group_nodes.iter().map(|n| n.id.clone()).collect();
+        let group_node_ids: BTreeSet<NodeId> = group_nodes.iter().map(|n| n.id).collect();
         let edges_for_group = filter_edges_for_cluster(&group_node_ids, &all_edges);
         let components = find_connected_components(group_nodes, &edges_for_group);
         for (i, comp) in components.into_iter().enumerate() {
-            let comp_ids: BTreeSet<NodeId> = comp.iter().map(|n| n.id.clone()).collect();
+            let comp_ids: BTreeSet<NodeId> = comp.iter().map(|n| n.id).collect();
             let edges_in_comp = filter_edges_for_cluster(&comp_ids, &all_edges);
             sub_clusters.push(Cluster {
                 name: format!("{}{}{}", group_name, name_suffix, i + 1),
@@ -340,7 +340,7 @@ pub fn compute_basic_graph_repr(sys: &System) -> GraphRepr {
     // 1. System rule instances.
     for (nid, ru) in sys.nodes.iter() {
         nodes.push(GNode {
-            id: nid.clone(),
+            id: *nid,
             ty: NodeType::System(ru.clone()),
         });
     }
@@ -356,12 +356,12 @@ pub fn compute_basic_graph_repr(sys: &System) -> GraphRepr {
             continue;
         }
         if let Goal::Action(nid, fa) = g {
-            by_node.entry(nid.clone()).or_default().push(fa.clone());
+            by_node.entry(*nid).or_default().push(fa.clone());
         }
     }
     for (nid, facts) in by_node {
         nodes.push(GNode {
-            id: nid.clone(),
+            id: nid,
             ty: NodeType::UnsolvedAction(facts),
         });
     }
@@ -376,7 +376,7 @@ pub fn compute_basic_graph_repr(sys: &System) -> GraphRepr {
     // colliding dot-id is disambiguated in `dot.rs`.
     if let Some(la) = &sys.last_atom {
         nodes.push(GNode {
-            id: la.clone(),
+            id: *la,
             ty: NodeType::LastAction,
         });
     }
@@ -391,16 +391,16 @@ pub fn compute_basic_graph_repr(sys: &System) -> GraphRepr {
     // nodes: two edges sharing the same missing endpoint emit it twice.
     // `systemMissingNodes` never inspects `sLessAtoms`; less-atoms contribute
     // edges (below), not nodes.
-    let sys_node_ids: BTreeSet<NodeId> = sys.nodes.iter().map(|(id, _)| id.clone()).collect();
+    let sys_node_ids: BTreeSet<NodeId> = sys.nodes.iter().map(|(id, _)| *id).collect();
     for e in &sys.edges {
         if !sys_node_ids.contains(&e.src.0) {
             nodes.push(GNode {
-                id: e.src.0.clone(),
+                id: e.src.0,
                 ty: NodeType::Missing(MissingHint::Conc(e.src.1)),
             });
         } else if !sys_node_ids.contains(&e.tgt.0) {
             nodes.push(GNode {
-                id: e.tgt.0.clone(),
+                id: e.tgt.0,
                 ty: NodeType::Missing(MissingHint::Prem(e.tgt.1)),
             });
         }
@@ -408,7 +408,7 @@ pub fn compute_basic_graph_repr(sys: &System) -> GraphRepr {
     // 5. Edges.
     let mut edges: Vec<GEdge> = Vec::new();
     for e in &sys.edges {
-        edges.push(GEdge::System(e.src.clone(), e.tgt.clone()));
+        edges.push(GEdge::System(e.src, e.tgt));
     }
     for la in &sys.less_atoms {
         edges.push(GEdge::Less(la.clone()));
@@ -418,7 +418,7 @@ pub fn compute_basic_graph_repr(sys: &System) -> GraphRepr {
             continue;
         }
         if let Goal::Chain(src, tgt) = g {
-            edges.push(GEdge::UnsolvedChain(src.clone(), tgt.clone()));
+            edges.push(GEdge::UnsolvedChain(*src, *tgt));
         }
     }
     GraphRepr {

--- a/crates/tamarin-server/src/graph/repr.rs
+++ b/crates/tamarin-server/src/graph/repr.rs
@@ -553,7 +553,7 @@ mod tests {
         ];
         let comps = find_connected_components(&input, &edges);
         assert_eq!(comps.len(), 1);
-        let ids: Vec<NodeId> = comps[0].iter().map(|n| n.id.clone()).collect();
+        let ids: Vec<NodeId> = comps[0].iter().map(|n| n.id).collect();
         // Original order [B, C, A], NOT DFS order [B, A, C].
         assert_eq!(ids, vec![nid("i", 2), nid("i", 3), nid("i", 1)]);
     }

--- a/crates/tamarin-server/src/graph/simplify.rs
+++ b/crates/tamarin-server/src/graph/simplify.rs
@@ -106,9 +106,7 @@ fn unsolved_chain_pairs(sys: &System) -> Vec<(NodeId, NodeId)> {
 fn build_raw_edge_adjacency(sys: &System) -> BTreeMap<NodeId, Vec<NodeId>> {
     let mut adj: BTreeMap<NodeId, Vec<NodeId>> = BTreeMap::new();
     for e in &sys.edges {
-        adj.entry(e.src.0)
-            .or_default()
-            .push(e.tgt.0);
+        adj.entry(e.src.0).or_default().push(e.tgt.0);
     }
     for (from, to) in unsolved_chain_pairs(sys) {
         adj.entry(from).or_default().push(to);

--- a/crates/tamarin-server/src/graph/simplify.rs
+++ b/crates/tamarin-server/src/graph/simplify.rs
@@ -45,11 +45,11 @@ pub fn compress_system(mut sys: RenderSystem) -> RenderSystem {
     // name).
     let mut frees: BTreeSet<NodeId> = BTreeSet::new();
     for la in &sys.less_atoms {
-        frees.insert(la.smaller.clone());
-        frees.insert(la.larger.clone());
+        frees.insert(la.smaller);
+        frees.insert(la.larger);
     }
     for (id, _) in sys.nodes.iter() {
-        frees.insert(id.clone());
+        frees.insert(*id);
     }
     for v in frees {
         sys = try_hide_node_id(&v, sys);
@@ -93,7 +93,7 @@ fn unsolved_chain_pairs(sys: &System) -> Vec<(NodeId, NodeId)> {
                 return None;
             }
             if let Goal::Chain(src, tgt) = g {
-                Some((src.0.clone(), tgt.0.clone()))
+                Some((src.0, tgt.0))
             } else {
                 None
             }
@@ -106,9 +106,9 @@ fn unsolved_chain_pairs(sys: &System) -> Vec<(NodeId, NodeId)> {
 fn build_raw_edge_adjacency(sys: &System) -> BTreeMap<NodeId, Vec<NodeId>> {
     let mut adj: BTreeMap<NodeId, Vec<NodeId>> = BTreeMap::new();
     for e in &sys.edges {
-        adj.entry(e.src.0.clone())
+        adj.entry(e.src.0)
             .or_default()
-            .push(e.tgt.0.clone());
+            .push(e.tgt.0);
     }
     for (from, to) in unsolved_chain_pairs(sys) {
         adj.entry(from).or_default().push(to);
@@ -120,17 +120,17 @@ fn reachable(adj: &BTreeMap<NodeId, Vec<NodeId>>, from: &NodeId, to: &NodeId) ->
     if from == to {
         return false;
     }
-    let mut stack: Vec<NodeId> = vec![from.clone()];
+    let mut stack: Vec<NodeId> = vec![*from];
     let mut visited: BTreeSet<NodeId> = BTreeSet::new();
-    visited.insert(from.clone());
+    visited.insert(*from);
     while let Some(cur) = stack.pop() {
         if let Some(nbrs) = adj.get(&cur) {
             for nb in nbrs {
                 if nb == to {
                     return true;
                 }
-                if visited.insert(nb.clone()) {
-                    stack.push(nb.clone());
+                if visited.insert(*nb) {
+                    stack.push(*nb);
                 }
             }
         }
@@ -246,7 +246,7 @@ fn try_hide_action(v: &NodeId, sys: RenderSystem) -> Result<RenderSystem, Render
             }
             if let Goal::Action(n, fa) = g {
                 if n == v && matches!(fa.tag, FactTag::Ku) && !fa.terms.is_empty() {
-                    return Some((n.clone(), fa.clone()));
+                    return Some((*n, fa.clone()));
                 }
             }
             None
@@ -299,8 +299,8 @@ fn try_hide_action(v: &NodeId, sys: RenderSystem) -> Result<RenderSystem, Render
         .iter()
         .flat_map(|i| {
             l_outs.iter().map(move |o| LessAtom {
-                smaller: i.smaller.clone(),
-                larger: o.larger.clone(),
+                smaller: i.smaller,
+                larger: o.larger,
                 reason: o.reason,
             })
         })
@@ -374,8 +374,8 @@ fn try_hide_rule(
         .iter()
         .flat_map(|ei| {
             e_outs.iter().map(move |eo| Edge {
-                src: ei.src.clone(),
-                tgt: eo.tgt.clone(),
+                src: ei.src,
+                tgt: eo.tgt,
             })
         })
         .collect();
@@ -484,10 +484,10 @@ pub fn transitive_reduction(sys: RenderSystem, total_red: bool) -> RenderSystem 
     let mut old_lesses: Vec<(NodeId, NodeId)> = sys
         .less_atoms
         .iter()
-        .map(|la| (la.smaller.clone(), la.larger.clone()))
+        .map(|la| (la.smaller, la.larger))
         .collect();
     for e in &sys.edges {
-        old_lesses.push((e.src.0.clone(), e.tgt.0.clone()));
+        old_lesses.push((e.src.0, e.tgt.0));
     }
     old_lesses.extend(unsolved_chain_pairs(&sys));
     // If there's a cycle in the combined graph we bail, matching Haskell's
@@ -504,7 +504,7 @@ pub fn transitive_reduction(sys: RenderSystem, total_red: bool) -> RenderSystem 
         .collect();
     let mut sys = sys;
     sys.content_mut().less_atoms.retain(|la| {
-        let p = (la.smaller.clone(), la.larger.clone());
+        let p = (la.smaller, la.larger);
         if total_red {
             kept.contains(&p)
         } else {

--- a/crates/tamarin-server/src/graph/simplify.rs
+++ b/crates/tamarin-server/src/graph/simplify.rs
@@ -637,16 +637,16 @@ mod tests {
         let n1 = nid("i", 1);
         let n2 = nid("i", 2);
         let n3 = nid("i", 3);
-        sys.add_node(n1.clone(), r1);
-        sys.add_node(n2.clone(), r2);
-        sys.add_node(n3.clone(), r3);
+        sys.add_node(n1, r1);
+        sys.add_node(n2, r2);
+        sys.add_node(n3, r3);
         sys.content_mut().edges.push(Edge {
-            src: (n1.clone(), ConcIdx(0)),
-            tgt: (n2.clone(), PremIdx(0)),
+            src: (n1, ConcIdx(0)),
+            tgt: (n2, PremIdx(0)),
         });
         sys.content_mut().edges.push(Edge {
-            src: (n2.clone(), ConcIdx(0)),
-            tgt: (n3.clone(), PremIdx(0)),
+            src: (n2, ConcIdx(0)),
+            tgt: (n3, PremIdx(0)),
         });
         let out = compress_system(RenderSystem::from_prover(sys));
         assert!(
@@ -680,7 +680,7 @@ mod tests {
             vec![out_fact(kvar.clone())], // has an action
         );
         let n1 = nid("i", 1);
-        sys.add_node(n1.clone(), r1);
+        sys.add_node(n1, r1);
         let out = compress_system(RenderSystem::from_prover(sys));
         assert!(out.nodes.iter().any(|(id, _)| id == &n1));
     }
@@ -722,16 +722,16 @@ mod tests {
         let n1 = nid("i", 1);
         let n2 = nid("i", 2);
         let n3 = nid("i", 3);
-        sys.add_node(n1.clone(), r1);
-        sys.add_node(n2.clone(), r2);
-        sys.add_node(n3.clone(), r3);
+        sys.add_node(n1, r1);
+        sys.add_node(n2, r2);
+        sys.add_node(n3, r3);
         sys.content_mut().edges.push(Edge {
-            src: (n1.clone(), ConcIdx(0)),
-            tgt: (n2.clone(), PremIdx(0)),
+            src: (n1, ConcIdx(0)),
+            tgt: (n2, PremIdx(0)),
         });
         sys.content_mut().edges.push(Edge {
-            src: (n2.clone(), ConcIdx(0)),
-            tgt: (n3.clone(), PremIdx(0)),
+            src: (n2, ConcIdx(0)),
+            tgt: (n3, PremIdx(0)),
         });
         let out = compress_system(RenderSystem::from_prover(sys));
         assert!(

--- a/crates/tamarin-server/src/handlers/dot.rs
+++ b/crates/tamarin-server/src/handlers/dot.rs
@@ -1855,13 +1855,13 @@ mod tests {
         let c = LVar::new("c", tamarin_term::lterm::LSort::Node, 0);
         sys.content_mut()
             .less_atoms
-            .push(LessAtom::new(a.clone(), b.clone(), Reason::Fresh));
+            .push(LessAtom::new(a, b, Reason::Fresh));
         sys.content_mut()
             .less_atoms
-            .push(LessAtom::new(b.clone(), c.clone(), Reason::Fresh));
+            .push(LessAtom::new(b, c, Reason::Fresh));
         sys.content_mut()
             .less_atoms
-            .push(LessAtom::new(a.clone(), c.clone(), Reason::Fresh));
+            .push(LessAtom::new(a, c, Reason::Fresh));
         let opts_sl0 = crate::graph::GraphOptions {
             simplification_level: crate::graph::SimplificationLevel::SL0,
             compress: false,
@@ -2168,11 +2168,11 @@ mod tests {
         );
         let j = LVar::new("j", LSort::Node, 0);
         let v = LVar::new("v", LSort::Node, 0);
-        sys.add_node(j.clone(), coerce);
-        sys.add_node(v.clone(), isend);
+        sys.add_node(j, coerce);
+        sys.add_node(v, isend);
         sys.content_mut().edges.push(Edge {
-            src: (j.clone(), ConcIdx(0)),
-            tgt: (v.clone(), PremIdx(0)),
+            src: (j, ConcIdx(0)),
+            tgt: (v, PremIdx(0)),
         });
         let out = system_to_dot_with(&sys, &opts);
         // Outgoing coerce: `#j : coerce` (its `Act(..)` action is dropped).

--- a/crates/tamarin-server/src/handlers/dot.rs
+++ b/crates/tamarin-server/src/handlers/dot.rs
@@ -270,11 +270,11 @@ pub fn system_to_dot_with(sys: &System, opts: &GraphOptions) -> String {
                     base
                 };
                 used_dot_ids.insert(id.clone());
-                ellipse_dot_ids.insert((node.id.clone(), tag), id.clone());
+                ellipse_dot_ids.insert((node.id, tag), id.clone());
                 id
             }
         };
-        ds_nodes.insert(node.id.clone(), id);
+        ds_nodes.insert(node.id, id);
     }
     // 4a. Top-level (ungrouped) nodes.
     //
@@ -378,7 +378,7 @@ fn emit_node_colored(
     // non-record ellipse node (UnsolvedAction tag 0 / LastAction tag 1).
     let ellipse_id = |tag: u8| -> String {
         ellipse_dot_ids
-            .get(&(node.id.clone(), tag))
+            .get(&(node.id, tag))
             .cloned()
             .unwrap_or_else(|| DotBuilder::dot_node_id(&node.id))
     };
@@ -1395,7 +1395,7 @@ fn build_node_color_map(nodes: &[(NodeId, RuleACInst)]) -> NodeColorMap<'_> {
 
     // `M.elems $ get sNodes se`: iterate in NodeId (Map key) order.
     let mut ordered: Vec<&(NodeId, RuleACInst)> = nodes.iter().collect();
-    ordered.sort_by(|a, b| a.0.cmp(&b.0));
+    ordered.sort_by_key(|a| a.0);
 
     // `groups = [ (gIdx, [ru | ru <- rules, gIdx == groupIdx ru]) | gIdx <- 0..3 ]`
     // — order-preserving partition into four groups.
@@ -1528,7 +1528,7 @@ fn lookup_conc_tag(
 ) -> Option<FactTag> {
     let (nid, idx) = nc;
     let ru = node_map.get(nid)?;
-    ru.conclusions.get(idx.0).map(|fa| fa.tag.clone())
+    ru.conclusions.get(idx.0).map(|fa| fa.tag)
 }
 
 fn lookup_prem_tag(
@@ -1537,7 +1537,7 @@ fn lookup_prem_tag(
 ) -> Option<FactTag> {
     let (nid, idx) = np;
     let ru = node_map.get(nid)?;
-    ru.premises.get(idx.0).map(|fa| fa.tag.clone())
+    ru.premises.get(idx.0).map(|fa| fa.tag)
 }
 
 fn reason_color(r: Reason) -> &'static str {

--- a/crates/tamarin-term/src/lterm.rs
+++ b/crates/tamarin-term/src/lterm.rs
@@ -474,7 +474,7 @@ pub trait HasFrees {
 /// `freesList`: every free `LVar`, in traversal order (with duplicates).
 pub fn frees_list<T: HasFrees>(t: &T) -> Vec<LVar> {
     let mut out = Vec::new();
-    t.for_each_free(&mut |v| out.push(v.clone()));
+    t.for_each_free(&mut |v| out.push(*v));
     out
 }
 

--- a/crates/tamarin-term/src/lterm.rs
+++ b/crates/tamarin-term/src/lterm.rs
@@ -785,7 +785,7 @@ mod tests {
     #[test]
     fn lvar_predicates() {
         let v = LVar::new("x", LSort::Msg, 0);
-        let t: LNTerm = var_term(v.clone());
+        let t: LNTerm = var_term(v);
         assert!(is_msg_var(&t));
         assert!(!is_pub_var(&t));
         assert_eq!(get_var(&t), Some(&v));

--- a/crates/tamarin-term/src/lterm.rs
+++ b/crates/tamarin-term/src/lterm.rs
@@ -84,7 +84,7 @@ pub fn sort_suffix(s: LSort) -> &'static str {
 // Names
 // =============================================================================
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct NameId(pub &'static str);
 
 impl NameId {
@@ -104,7 +104,7 @@ pub enum NameTag {
     Nat,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Name {
     pub tag: NameTag,
     pub id: NameId,
@@ -168,7 +168,7 @@ pub fn sort_of_name(n: &Name) -> LSort {
 /// pattern vars (small idx like t.1, t.2) are NEVER keys, so all
 /// stable-keyed bindings drop and pattern vars stay unbound for runtime
 /// `applySource` to bind cleanly.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct LVar {
     /// Interned `&'static str` (see [`crate::intern`]): clone is a pointer
     /// copy — no alloc, no atomic refcount — and equal names share one copy.

--- a/crates/tamarin-term/src/macro_expand.rs
+++ b/crates/tamarin-term/src/macro_expand.rs
@@ -143,7 +143,7 @@ mod tests {
         // `pair(b, a)`.
         let x = crate::lterm::LVar::new("x", crate::lterm::LSort::Msg, 0);
         let y = crate::lterm::LVar::new("y", crate::lterm::LSort::Msg, 0);
-        let body: LNTerm = pair(var_term(y.clone()), var_term(x.clone()));
+        let body: LNTerm = pair(var_term(y), var_term(x));
         let m = Macro::new(b"swap".to_vec(), vec![x, y], body);
 
         let invoke: LNTerm = crate::term::f_app_no_eq(

--- a/crates/tamarin-term/src/maude_proc.rs
+++ b/crates/tamarin-term/src/maude_proc.rs
@@ -1619,8 +1619,8 @@ fn build_skolem_maps(
     let mut reverse = std::collections::BTreeMap::new();
     for (counter, lv) in (0_u64..).zip(vars.iter()) {
         let n = skolem_name(counter, lv);
-        skolem_map.insert(lv.clone(), n.clone());
-        reverse.insert(n, lv.clone());
+        skolem_map.insert(*lv, n);
+        reverse.insert(n, *lv);
     }
     (skolem_map, reverse)
 }
@@ -1698,7 +1698,7 @@ fn unskolemize(
     match t {
         crate::term::Term::Lit(Lit::Con(n)) => {
             if let Some(lv) = reverse.get(n) {
-                crate::term::Term::Lit(Lit::Var(lv.clone()))
+                crate::term::Term::Lit(Lit::Var(*lv))
             } else {
                 t.clone()
             }
@@ -1725,7 +1725,7 @@ fn collect_free_non_pattern_vars(
         crate::term::Term::Lit(Lit::Var(lv))
             if !pattern_vars.contains(&(lv.name.to_string(), lv.idx)) =>
         {
-            out.insert(lv.clone());
+            out.insert(*lv);
         }
         crate::term::Term::App(_, args) => {
             for a in args.iter() {
@@ -1747,7 +1747,7 @@ fn rewrite_skolem(
     match t {
         crate::term::Term::Lit(Lit::Var(lv)) => {
             if let Some(n) = map.get(lv) {
-                crate::term::Term::Lit(Lit::Con(n.clone()))
+                crate::term::Term::Lit(Lit::Con(*n))
             } else {
                 t.clone()
             }

--- a/crates/tamarin-term/src/maude_proc.rs
+++ b/crates/tamarin-term/src/maude_proc.rs
@@ -2189,8 +2189,8 @@ mod tests {
         let h = MaudeHandle::start(&path, pair_maude_sig()).expect("start");
         let x = LVar::new("x", LSort::Msg, 0);
         let y = LVar::new("y", LSort::Msg, 0);
-        let tx: LNTerm = crate::term::Term::Lit(Lit::Var(x.clone()));
-        let ty: LNTerm = crate::term::Term::Lit(Lit::Var(y.clone()));
+        let tx: LNTerm = crate::term::Term::Lit(Lit::Var(x));
+        let ty: LNTerm = crate::term::Term::Lit(Lit::Var(y));
         let unifiers = h.unify(&[Equal { lhs: tx, rhs: ty }]).expect("unify");
         // Two free variables of the same sort have a single mgu (a renaming).
         assert!(!unifiers.is_empty());
@@ -2244,8 +2244,8 @@ mod tests {
         let h = MaudeHandle::start(&path, pair_maude_sig()).expect("start");
         let x_msg = LVar::new("x", LSort::Msg, 0);
         let y_pub = LVar::new("y", LSort::Pub, 0);
-        let tx: LNTerm = crate::term::Term::Lit(Lit::Var(x_msg.clone()));
-        let ty: LNTerm = crate::term::Term::Lit(Lit::Var(y_pub.clone()));
+        let tx: LNTerm = crate::term::Term::Lit(Lit::Var(x_msg));
+        let ty: LNTerm = crate::term::Term::Lit(Lit::Var(y_pub));
         let unifiers = h.unify(&[Equal { lhs: tx, rhs: ty }]).expect("unify");
         assert_eq!(unifiers.len(), 1);
         // Both vars should be bound to a fresh variable of sort Pub.
@@ -2479,7 +2479,7 @@ mod tests {
         let t = crate::term::f_app_ac(
             crate::function_symbols::AcSym::Xor,
             vec![
-                crate::term::Term::Lit(Lit::Var(x.clone())),
+                crate::term::Term::Lit(Lit::Var(x)),
                 crate::term::Term::Lit(Lit::Var(x)),
             ],
         );
@@ -2573,13 +2573,13 @@ mod tests {
         // pattern var codeOther:Msg idx 89 (the universal-bound var)
         let code_other = LVar::new("codeOther", LSort::Msg, 89);
         let pat =
-            crate::term::f_app_ac(AcSym::Union, vec![mk(code_other.clone()), payload.clone()]);
+            crate::term::f_app_ac(AcSym::Union, vec![mk(code_other), payload.clone()]);
         // subject: code2:Msg, x:Msg (free system vars, skolemized by the fn)
         let code2 = LVar::new("code2", LSort::Msg, 8);
         let xv = LVar::new("x", LSort::Msg, 9);
         let subj = crate::term::f_app_ac(
             AcSym::Union,
-            vec![mk(code2.clone()), mk(xv.clone()), payload.clone()],
+            vec![mk(code2), mk(xv), payload.clone()],
         );
         let mut pattern_vars = std::collections::BTreeSet::new();
         pattern_vars.insert(("codeOther".to_string(), 89u64));
@@ -2653,12 +2653,12 @@ mod tests {
         let tid = LVar::new("tid", LSort::Fresh, 15);
         let eqs = vec![
             Equal {
-                lhs: exp(g.clone(), mk(ek_i.clone())),
-                rhs: exp(g.clone(), mk(xv.clone())),
+                lhs: exp(g.clone(), mk(ek_i)),
+                rhs: exp(g.clone(), mk(xv)),
             },
             Equal {
-                lhs: exp(g.clone(), mk(ek_r.clone())),
-                rhs: exp(g.clone(), mk(tid.clone())),
+                lhs: exp(g.clone(), mk(ek_r)),
+                rhs: exp(g.clone(), mk(tid)),
             },
         ];
         // No universal-bound vars in these positions.

--- a/crates/tamarin-term/src/maude_proc.rs
+++ b/crates/tamarin-term/src/maude_proc.rs
@@ -2572,15 +2572,11 @@ mod tests {
         let payload = crate::term::Term::App(FunSym::NoEq(pair_sym), vec![a, b].into());
         // pattern var codeOther:Msg idx 89 (the universal-bound var)
         let code_other = LVar::new("codeOther", LSort::Msg, 89);
-        let pat =
-            crate::term::f_app_ac(AcSym::Union, vec![mk(code_other), payload.clone()]);
+        let pat = crate::term::f_app_ac(AcSym::Union, vec![mk(code_other), payload.clone()]);
         // subject: code2:Msg, x:Msg (free system vars, skolemized by the fn)
         let code2 = LVar::new("code2", LSort::Msg, 8);
         let xv = LVar::new("x", LSort::Msg, 9);
-        let subj = crate::term::f_app_ac(
-            AcSym::Union,
-            vec![mk(code2), mk(xv), payload.clone()],
-        );
+        let subj = crate::term::f_app_ac(AcSym::Union, vec![mk(code2), mk(xv), payload.clone()]);
         let mut pattern_vars = std::collections::BTreeSet::new();
         pattern_vars.insert(("codeOther".to_string(), 89u64));
         let res = h

--- a/crates/tamarin-term/src/maude_sig.rs
+++ b/crates/tamarin-term/src/maude_sig.rs
@@ -108,7 +108,7 @@ impl MaudeSig {
 
         let irreducible: FunSig = all_funs
             .difference(&reducible_without_mult)
-            .cloned()
+            .copied()
             .collect();
 
         let mut reducible: FunSig = BTreeSet::new();
@@ -121,8 +121,8 @@ impl MaudeSig {
         // Hash-set mirrors for O(1) membership in the proof-search hot path.
         // Kept in lock-step with the BTreeSets above (same elements), so every
         // `.contains()` answer is identical — only the cost differs.
-        self.irreducible_fun_syms_fast = irreducible.iter().cloned().collect();
-        self.reducible_fun_syms_fast = reducible.iter().cloned().collect();
+        self.irreducible_fun_syms_fast = irreducible.iter().copied().collect();
+        self.reducible_fun_syms_fast = reducible.iter().copied().collect();
         self.fun_syms = all_funs;
         self.irreducible_fun_syms = irreducible;
         self.reducible_fun_syms = reducible;
@@ -232,7 +232,7 @@ impl MaudeSig {
             macro_names: self
                 .macro_names
                 .union(&other.macro_names)
-                .cloned()
+                .copied()
                 .collect(),
             eq_convergent: false,
             fun_syms: BTreeSet::new(),
@@ -271,10 +271,10 @@ fn union_except_pair_sym(a: &BTreeSet<NoEqSym>, b: &BTreeSet<NoEqSym>) -> BTreeS
         if st2.contains(to_add) {
             let mut out: BTreeSet<NoEqSym> = st1.clone();
             out.remove(to_remove);
-            out.extend(st2.iter().cloned());
+            out.extend(st2.iter().copied());
             out
         } else {
-            st1.union(st2).cloned().collect()
+            st1.union(st2).copied().collect()
         }
     }
     // removeIfNecessary st1 st2 x y

--- a/crates/tamarin-term/src/maude_types.rs
+++ b/crates/tamarin-term/src/maude_types.rs
@@ -354,7 +354,7 @@ mod tests {
     #[test]
     fn round_trip_var() {
         let v = LVar::new("x", LSort::Msg, 0);
-        let t: LNTerm = var_term(v.clone());
+        let t: LNTerm = var_term(v);
         let _ = t;
         // Direct construction with the lit literal so we don't need to
         // construct an LNTerm from an LVar via var_term (which expects
@@ -382,7 +382,7 @@ mod tests {
         // Bind MaudeVar(6, Fresh) -> ~k1 (a Fresh-sorted LVar).
         let k1 = LVar::new("~k", LSort::Fresh, 1);
         ctx.inverse
-            .insert(MaudeLit::MaudeVar(6, LSort::Fresh), Lit::Var(k1.clone()));
+            .insert(MaudeLit::MaudeVar(6, LSort::Fresh), Lit::Var(k1));
         // Maude references it back with a WIDENED sort (Msg); the strict
         // (6, Msg) key misses, but the (idx, any-sort) fallback recovers
         // the original Fresh-sorted LVar.
@@ -403,7 +403,7 @@ mod tests {
         // ctx only has MaudeVar(idx, Fresh) bound.
         let k = LVar::new("~k", LSort::Fresh, 3);
         ctx.inverse
-            .insert(MaudeLit::MaudeVar(4, LSort::Fresh), Lit::Var(k.clone()));
+            .insert(MaudeLit::MaudeVar(4, LSort::Fresh), Lit::Var(k));
         // Maude hands back the SAME idx widened to Msg.
         let mt: MTerm = Term::Lit(MaudeLit::MaudeVar(4, LSort::Msg));
         let mut next = 50;
@@ -431,8 +431,8 @@ mod tests {
         let mut ctx = ConvCtx::new();
         let m0 = MaudeLit::MaudeVar(0, LSort::Msg);
         let m1 = MaudeLit::MaudeVar(1, LSort::Msg);
-        ctx.inverse.insert(m0.clone(), Lit::Var(x10.clone()));
-        ctx.inverse.insert(m1.clone(), Lit::Var(x9.clone()));
+        ctx.inverse.insert(m0.clone(), Lit::Var(x10));
+        ctx.inverse.insert(m1.clone(), Lit::Var(x9));
 
         let mt: MTerm = Term::App(
             FunSym::C(CSym::EMap),

--- a/crates/tamarin-term/src/norm.rs
+++ b/crates/tamarin-term/src/norm.rs
@@ -400,7 +400,7 @@ mod tests {
         let tid = LVar::new("tid", LSort::Fresh, 0);
         let ekI = LVar::new("ekI", LSort::Fresh, 0);
         let ekR = LVar::new("ekR", LSort::Fresh, 0);
-        let tid_term: LNTerm = Term::Lit(Lit::Var(tid.clone()));
+        let tid_term: LNTerm = Term::Lit(Lit::Var(tid));
         let ekI_term: LNTerm = Term::Lit(Lit::Var(ekI));
         let ekR_term: LNTerm = Term::Lit(Lit::Var(ekR));
         let inv_tid: LNTerm = Term::App(

--- a/crates/tamarin-term/src/subst_vfresh.rs
+++ b/crates/tamarin-term/src/subst_vfresh.rs
@@ -176,12 +176,7 @@ impl<C: Ord + Clone> LSubstVFresh<C> {
         let renamed: Vec<(LVar, VTerm<C, LVar>)> = self
             .map
             .iter()
-            .map(|(k, t)| {
-                (
-                    *k,
-                    rename_term_drop_hint(t, &mut bindings, &mut counter),
-                )
-            })
+            .map(|(k, t)| (*k, rename_term_drop_hint(t, &mut bindings, &mut counter)))
             .collect();
         Self::from_list(renamed)
     }

--- a/crates/tamarin-term/src/subst_vfresh.rs
+++ b/crates/tamarin-term/src/subst_vfresh.rs
@@ -130,7 +130,7 @@ fn rename_term_drop_hint<C: Ord + Clone>(
         Term::Lit(Lit::Con(c)) => Term::Lit(Lit::Con(c.clone())),
         Term::Lit(Lit::Var(v)) => {
             let nv = match bindings.get(v) {
-                Some(nv) => nv.clone(),
+                Some(nv) => *nv,
                 None => {
                     let nv = LVar {
                         name: "",
@@ -138,7 +138,7 @@ fn rename_term_drop_hint<C: Ord + Clone>(
                         idx: *counter,
                     };
                     *counter += 1;
-                    bindings.insert(v.clone(), nv.clone());
+                    bindings.insert(*v, nv);
                     nv
                 }
             };
@@ -178,7 +178,7 @@ impl<C: Ord + Clone> LSubstVFresh<C> {
             .iter()
             .map(|(k, t)| {
                 (
-                    k.clone(),
+                    *k,
                     rename_term_drop_hint(t, &mut bindings, &mut counter),
                 )
             })
@@ -253,7 +253,7 @@ impl<C: Ord + Clone> LSubstVFresh<C> {
             .map
             .iter()
             .filter(|(v, _)| !self.is_renamed_var(v))
-            .map(|(v, t)| (v.clone(), t.clone()))
+            .map(|(v, t)| (*v, t.clone()))
             .collect();
         SubstVFresh { map }
     }
@@ -279,8 +279,8 @@ impl<C: Ord + Clone> LSubstVFresh<C> {
             if self.image_of(v).is_some() {
                 continue;
             }
-            if seen.insert(v.clone()) {
-                vs_new.push(v.clone());
+            if seen.insert(*v) {
+                vs_new.push(*v);
             }
         }
         if vs_new.is_empty() {
@@ -315,7 +315,7 @@ impl<C: Ord + Clone> LSubstVFresh<C> {
                     sort: v.sort,
                     idx: new_idx,
                 };
-                (v.clone(), Term::Lit(Lit::Var(v_new)))
+                (*v, Term::Lit(Lit::Var(v_new)))
             })
             .collect();
         // `from_list(to_list() ++ new_entries)` would rebuild the whole map from
@@ -351,7 +351,7 @@ impl<C: Ord + Clone> LSubstVFresh<C> {
         if range_vars.is_empty() {
             // No range vars to rename — just downgrade (through `from_list`,
             // which drops trivial `x ~> x` mappings exactly as before).
-            return Subst::from_list(self.iter().map(|(v, t)| (v.clone(), t.clone())));
+            return Subst::from_list(self.iter().map(|(v, t)| (*v, t.clone())));
         }
         // HS: `evalFreshAvoiding t` initial counter = succ . maxIdx . frees t,
         // precomputed by the caller and handed in as `fresh_start`.
@@ -368,7 +368,7 @@ impl<C: Ord + Clone> LSubstVFresh<C> {
                 sort: old.sort,
                 idx: new_idx,
             };
-            rename.insert(old.clone(), new);
+            rename.insert(*old, new);
         }
         let mut pairs: Vec<(LVar, VTerm<C, LVar>)> = Vec::with_capacity(self.len());
         // Borrowing walk: the rename rebuilds every range term anyway, so read
@@ -376,7 +376,7 @@ impl<C: Ord + Clone> LSubstVFresh<C> {
         // `to_list`.
         for (v, t) in self.iter() {
             let renamed = rename_lvars_in_vterm(t, &rename);
-            pairs.push((v.clone(), renamed));
+            pairs.push((*v, renamed));
         }
         Subst::from_list(pairs)
     }
@@ -533,7 +533,7 @@ fn rename_lvars_with_hint<C: Ord + Clone, F: FnMut(u64) -> u64>(
                     sort: v.sort,
                     idx,
                 };
-                rename.insert(v.clone(), new.clone());
+                rename.insert(*v, new);
                 Term::Lit(Lit::Var(new))
             }
         }
@@ -643,7 +643,7 @@ where
     for t in s2.range() {
         for v in crate::vterm::vars_vterm(t) {
             max_idx = Some(max_idx.map_or(v.idx, |m| m.max(v.idx)));
-            if seen.insert(v.clone()) {
+            if seen.insert(v) {
                 range_vars.push(v);
             }
         }
@@ -674,7 +674,7 @@ where
             sort: w.sort,
             idx: up,
         };
-        s1_map.insert(w.clone(), Term::Lit(Lit::Var(w_prime)));
+        s1_map.insert(*w, Term::Lit(Lit::Var(w_prime)));
     }
     let mut out: Vec<(LVar, VTerm<C, LVar>)> = Vec::new();
     // `s1 `compose` s2` first arm = `s2.map_range(|t| apply_vterm(s1, t))`:
@@ -683,7 +683,7 @@ where
     for (v, t) in s2.iter() {
         let t2 = crate::subst::apply_vterm_map(&s1_map, t.clone());
         if !matches!(&t2, Term::Lit(Lit::Var(w)) if w == v) {
-            out.push((v.clone(), t2));
+            out.push((*v, t2));
         }
     }
     // `compose`'s second arm: s1's own bindings whose domain s2 does not
@@ -693,7 +693,7 @@ where
     for w in &range_vars {
         if s2.image_of(w).is_none() {
             // `s1_map[w]` exists for every range var by construction.
-            out.push((w.clone(), s1_map[w].clone()));
+            out.push((*w, s1_map[w].clone()));
         }
     }
     LSubstVFresh::from_list(out)
@@ -712,7 +712,7 @@ fn distinct_range_vars<'a, C: 'a>(range: impl Iterator<Item = &'a VTerm<C, LVar>
     let mut seen: tamarin_utils::FastSet<LVar> = Default::default();
     for t in range {
         for v in crate::vterm::vars_vterm(t) {
-            if seen.insert(v.clone()) {
+            if seen.insert(v) {
                 out.push(v);
             }
         }
@@ -802,7 +802,7 @@ fn rename_lvars_in_vterm<C: Clone>(
 ) -> VTerm<C, LVar> {
     match t {
         Term::Lit(Lit::Var(v)) => {
-            let new = rename.get(v).cloned().unwrap_or_else(|| v.clone());
+            let new = rename.get(v).cloned().unwrap_or(*v);
             Term::Lit(Lit::Var(new))
         }
         Term::Lit(other) => Term::Lit(other.clone()),

--- a/crates/tamarin-term/src/subst_vfresh.rs
+++ b/crates/tamarin-term/src/subst_vfresh.rs
@@ -512,7 +512,7 @@ fn rename_lvars_with_hint<C: Ord + Clone, F: FnMut(u64) -> u64>(
 ) -> VTerm<C, LVar> {
     match t {
         Term::Lit(Lit::Var(v)) => {
-            if let Some(new) = rename.get(v).cloned() {
+            if let Some(new) = rename.get(v).copied() {
                 Term::Lit(Lit::Var(new))
             } else {
                 // Allocate a fresh idx; name hint depends on outer
@@ -797,7 +797,7 @@ fn rename_lvars_in_vterm<C: Clone>(
 ) -> VTerm<C, LVar> {
     match t {
         Term::Lit(Lit::Var(v)) => {
-            let new = rename.get(v).cloned().unwrap_or(*v);
+            let new = rename.get(v).copied().unwrap_or(*v);
             Term::Lit(Lit::Var(new))
         }
         Term::Lit(other) => Term::Lit(other.clone()),

--- a/crates/tamarin-term/src/subsumption.rs
+++ b/crates/tamarin-term/src/subsumption.rs
@@ -205,7 +205,7 @@ fn show_funsym_ac_c(sym: &FunSym) -> String {
 /// AC/C operands being unordered).
 fn fold_frees_occ_term(t: &LNTerm, ctx: &Occurence, out: &mut Vec<(LVar, Occurence)>) {
     match t {
-        Term::Lit(Lit::Var(v)) => out.push((v.clone(), ctx.clone())),
+        Term::Lit(Lit::Var(v)) => out.push((*v, ctx.clone())),
         Term::Lit(_) => {}
         Term::App(FunSym::NoEq(o), args) => {
             // `FApp (NoEq o) as -> foldFreesOcc f ((unpack (fst o)):c) as`,
@@ -273,7 +273,7 @@ pub fn canonize_subst(subst: &LNSubstVFresh) -> LNSubstVFresh {
     // `LNTerm` var→term map `applyVTerm` consumes directly.
     let mut renaming: BTreeMap<LVar, LNTerm> = BTreeMap::new();
     for (i, v) in vrange.iter().enumerate() {
-        renaming.insert(v.clone(), var_term(LVar::new("x", v.sort, (i + 1) as u64)));
+        renaming.insert(*v, var_term(LVar::new("x", v.sort, (i + 1) as u64)));
     }
 
     // `mapRangeVFresh (applyVTerm renaming) subst`.  `apply_vterm_map` is the

--- a/crates/tamarin-term/src/unification.rs
+++ b/crates/tamarin-term/src/unification.rs
@@ -849,8 +849,8 @@ mod haskell_invariants {
                 .expect("non-AC same-sort vars must unify");
         assert!(residuals.is_empty(), "no AC stuff, no residuals");
         // Larger-idx (e.10) is the key.
-        let e_10 = as_var(&rule_internal).clone();
-        let t_1 = as_var(&stable).clone();
+        let e_10 = *as_var(&rule_internal);
+        let t_1 = *as_var(&stable);
         assert!(
             subst.image_of(&e_10).is_some(),
             "Haskell convention: larger-idx (e.10) must be a KEY"
@@ -876,7 +876,7 @@ mod haskell_invariants {
         let (s2, _) =
             unify_lnterm_factored(vec![Equal::new(rule_internal.clone(), stable.clone())]).unwrap();
 
-        let e_10 = as_var(&rule_internal).clone();
+        let e_10 = *as_var(&rule_internal);
         // Both directions: e.10 (larger idx) is the key, regardless of
         // whether it was on lhs or rhs of the equation.
         assert!(s1.image_of(&e_10).is_some());
@@ -895,8 +895,8 @@ mod haskell_invariants {
         let beta = msg_var("b", 3);
         let (subst, _) =
             unify_lnterm_factored(vec![Equal::new(alpha.clone(), beta.clone())]).unwrap();
-        let a_3 = as_var(&alpha).clone();
-        let b_3 = as_var(&beta).clone();
+        let a_3 = *as_var(&alpha);
+        let b_3 = *as_var(&beta);
         // Ord: a.3 < b.3 (idx tie → sort tie → name 'a' < 'b').
         // unifyRaw: vl=a.3, vr=b.3, vl<vr, elim vr l → b.3 is key.
         assert!(
@@ -926,8 +926,8 @@ mod haskell_invariants {
 
         let (subst, _) = unify_lnterm_factored(vec![Equal::new(m.clone(), f.clone())]).unwrap();
 
-        let m_v = as_var(&m).clone();
-        let f_v = as_var(&f).clone();
+        let m_v = *as_var(&m);
+        let f_v = *as_var(&f);
         // The Msg var (broader sort) must be the KEY.
         assert!(
             subst.image_of(&m_v).is_some(),
@@ -947,8 +947,8 @@ mod haskell_invariants {
 
         let (subst, _) = unify_lnterm_factored(vec![Equal::new(m.clone(), p.clone())]).unwrap();
 
-        let m_v = as_var(&m).clone();
-        let p_v = as_var(&p).clone();
+        let m_v = *as_var(&m);
+        let p_v = *as_var(&p);
         assert!(subst.image_of(&m_v).is_some(), "Msg (broader) is key");
         assert!(subst.image_of(&p_v).is_none(), "Pub (narrower) is value");
     }
@@ -985,7 +985,7 @@ mod haskell_invariants {
         let (s1, _) = unify_lnterm_factored(vec![Equal::new(x.clone(), p.clone())]).unwrap();
         let (s2, _) = unify_lnterm_factored(vec![Equal::new(p.clone(), x.clone())]).unwrap();
 
-        let x_v = as_var(&x).clone();
+        let x_v = *as_var(&x);
         assert_eq!(s1.image_of(&x_v), Some(&p));
         assert_eq!(s2.image_of(&x_v), Some(&p));
         assert_eq!(s1, s2);
@@ -1088,8 +1088,8 @@ mod haskell_invariants {
         ])
         .unwrap();
 
-        let t_1_v = as_var(&t_1).clone();
-        let m_19_v = as_var(&m_19).clone();
+        let t_1_v = *as_var(&t_1);
+        let m_19_v = *as_var(&m_19);
         assert_eq!(
             subst.image_of(&m_19_v),
             Some(&blind),
@@ -1149,8 +1149,8 @@ mod haskell_invariants {
         let (new_, _) =
             unify_lnterm_factored(vec![Equal::new(small.clone(), large.clone())]).unwrap();
 
-        let small_v = as_var(&small).clone();
-        let large_v = as_var(&large).clone();
+        let small_v = *as_var(&small);
+        let large_v = *as_var(&large);
 
         // Haskell-faithful: larger-idx is key in BOTH paths.
         assert!(

--- a/crates/tamarin-term/src/unification.rs
+++ b/crates/tamarin-term/src/unification.rs
@@ -154,9 +154,9 @@ where
                     //   `if vl < vr then elim vr l else elim vl r`
                     // Larger-idx becomes KEY, smaller-idx becomes value.
                     let (key, val) = if vl < vr {
-                        (vr.clone(), Term::Lit(Lit::Var(vl.clone())))
+                        (*vr, Term::Lit(Lit::Var(*vl)))
                     } else {
-                        (vl.clone(), Term::Lit(Lit::Var(vr.clone())))
+                        (*vl, Term::Lit(Lit::Var(*vr)))
                     };
                     eliminate(sort_of_const, acc, key, val)
                 }
@@ -165,8 +165,8 @@ where
                     eliminate(
                         sort_of_const,
                         acc,
-                        vl.clone(),
-                        Term::Lit(Lit::Var(vr.clone())),
+                        *vl,
+                        Term::Lit(Lit::Var(*vr)),
                     )
                 }
                 Some(Ordering::Less) => {
@@ -174,15 +174,15 @@ where
                     eliminate(
                         sort_of_const,
                         acc,
-                        vr.clone(),
-                        Term::Lit(Lit::Var(vl.clone())),
+                        *vr,
+                        Term::Lit(Lit::Var(*vl)),
                     )
                 }
                 None => Err(UnifyError::NoUnifier),
             }
         }
-        (Term::Lit(Lit::Var(vl)), _) => eliminate(sort_of_const, acc, vl.clone(), r.clone()),
-        (_, Term::Lit(Lit::Var(vr))) => eliminate(sort_of_const, acc, vr.clone(), l.clone()),
+        (Term::Lit(Lit::Var(vl)), _) => eliminate(sort_of_const, acc, *vl, r.clone()),
+        (_, Term::Lit(Lit::Var(vr))) => eliminate(sort_of_const, acc, *vr, l.clone()),
         (Term::Lit(Lit::Con(cl)), Term::Lit(Lit::Con(cr))) => {
             if cl == cr {
                 Ok(())
@@ -349,9 +349,9 @@ where
     // Substitute `v ~> t` through the existing accumulator in place, mutating
     // each value rather than rebuilding the whole map with cloned keys.
     let mut single = BTreeMap::new();
-    single.insert(v.clone(), t.clone());
+    single.insert(v, t.clone());
     for ts in acc.values_mut() {
-        let cur = std::mem::replace(ts, Term::Lit(Lit::Var(v.clone())));
+        let cur = std::mem::replace(ts, Term::Lit(Lit::Var(v)));
         *ts = apply_vterm_map(&single, cur);
     }
     acc.insert(v, t);

--- a/crates/tamarin-term/src/unification.rs
+++ b/crates/tamarin-term/src/unification.rs
@@ -162,21 +162,11 @@ where
                 }
                 Some(Ordering::Greater) => {
                     // vl > vr (vl is broader) → bind vl to vr.
-                    eliminate(
-                        sort_of_const,
-                        acc,
-                        *vl,
-                        Term::Lit(Lit::Var(*vr)),
-                    )
+                    eliminate(sort_of_const, acc, *vl, Term::Lit(Lit::Var(*vr)))
                 }
                 Some(Ordering::Less) => {
                     // vl < vr (vr is broader) → bind vr to vl.
-                    eliminate(
-                        sort_of_const,
-                        acc,
-                        *vr,
-                        Term::Lit(Lit::Var(*vl)),
-                    )
+                    eliminate(sort_of_const, acc, *vr, Term::Lit(Lit::Var(*vl)))
                 }
                 None => Err(UnifyError::NoUnifier),
             }

--- a/crates/tamarin-theory/src/auto_sources.rs
+++ b/crates/tamarin-theory/src/auto_sources.rs
@@ -392,7 +392,7 @@ pub fn add_auto_sources_lemma(
             let t_is_eligible = tamarin_term::term::is_pair(&t)
                 || tamarin_term::term::is_ac(&t)
                 || tamarin_term::lterm::is_msg_var(&t);
-            if is_proto && t_is_eligible && unsolved_prem_keys.contains(&(nodeid.clone(), pid)) {
+            if is_proto && t_is_eligible && unsolved_prem_keys.contains(&(nodeid, pid)) {
                 for pos in &positions {
                     input_rules.push((ri, InRule::Fact(premise.clone()), (pid, tidx, pos.clone())));
                 }

--- a/crates/tamarin-theory/src/constraint/constraints.rs
+++ b/crates/tamarin-theory/src/constraint/constraints.rs
@@ -91,7 +91,7 @@ impl LessAtom {
     }
 
     pub fn to_edge(&self) -> (NodeId, NodeId) {
-        (self.smaller.clone(), self.larger.clone())
+        (self.smaller, self.larger)
     }
 }
 

--- a/crates/tamarin-theory/src/constraint/solver/context.rs
+++ b/crates/tamarin-theory/src/constraint/solver/context.rs
@@ -751,7 +751,7 @@ impl ProofContext {
         // in some fact term could narrow. Skipping non-destructor
         // rules avoids ~N Maude round-trips at theory-load time.
         let reducible_syms: std::collections::BTreeSet<_> =
-            sig.reducible_fun_syms.iter().cloned().collect();
+            sig.reducible_fun_syms.iter().copied().collect();
         let term_has_reducible = |t: &tamarin_term::lterm::LNTerm| -> bool {
             fn rec(
                 t: &tamarin_term::lterm::LNTerm,

--- a/crates/tamarin-theory/src/constraint/solver/context.rs
+++ b/crates/tamarin-theory/src/constraint/solver/context.rs
@@ -1118,7 +1118,7 @@ pub fn annotate_loop_breakers(
                     .iter()
                     .map(|t| tamarin_term::subst::apply_vterm(&free, t.clone()))
                     .collect();
-                crate::fact::LNFact::fresh_annotated(fa.tag.clone(), fa.annotations.clone(), terms)
+                crate::fact::LNFact::fresh_annotated(fa.tag, fa.annotations.clone(), terms)
             })
             .collect()
     };

--- a/crates/tamarin-theory/src/constraint/solver/contradictions.rs
+++ b/crates/tamarin-theory/src/constraint/solver/contradictions.rs
@@ -1895,7 +1895,7 @@ pub fn cyclic(less: &[LessAtom]) -> bool {
     }
     // Run DFS detecting back-edges.
     let mut color: BTreeMap<NodeId, u8> = BTreeMap::new(); // 0=white,1=gray,2=black
-    let nodes: Vec<NodeId> = adj.keys().cloned().collect();
+    let nodes: Vec<NodeId> = adj.keys().copied().collect();
     fn dfs(
         node: &NodeId,
         adj: &BTreeMap<NodeId, Vec<NodeId>>,
@@ -1940,7 +1940,7 @@ pub fn cyclic_with_path(less: &[LessAtom]) -> Vec<NodeId> {
     }
     let mut color: BTreeMap<NodeId, u8> = BTreeMap::new();
     let mut path: Vec<NodeId> = Vec::new();
-    let nodes: Vec<NodeId> = adj.keys().cloned().collect();
+    let nodes: Vec<NodeId> = adj.keys().copied().collect();
     fn dfs(
         node: &NodeId,
         adj: &BTreeMap<NodeId, Vec<NodeId>>,

--- a/crates/tamarin-theory/src/constraint/solver/contradictions.rs
+++ b/crates/tamarin-theory/src/constraint/solver/contradictions.rs
@@ -834,10 +834,7 @@ fn has_forbidden_chain(sys: &System, ab_adj: &crate::constraint::system::Prebuil
                         if vi == vj {
                             continue;
                         }
-                        equivalence_classes
-                            .entry(*vi)
-                            .or_default()
-                            .insert(*vj);
+                        equivalence_classes.entry(*vi).or_default().insert(*vj);
                     }
                 }
             }
@@ -1697,11 +1694,7 @@ fn non_injective_fact_instances(
             let k_after_j = j_reach.contains(&k);
             let k_is_last = sys.last_atom.as_ref() == Some(&k);
             if k_after_j || k_is_last {
-                out.push(Contradiction::NonInjectiveFactInstance(
-                    i,
-                    *j,
-                    k,
-                ));
+                out.push(Contradiction::NonInjectiveFactInstance(i, *j, k));
             }
         }
     }
@@ -1898,9 +1891,7 @@ pub fn cyclic(less: &[LessAtom]) -> bool {
     // Build adjacency list keyed by NodeId.
     let mut adj: BTreeMap<NodeId, Vec<NodeId>> = BTreeMap::new();
     for l in less {
-        adj.entry(l.smaller)
-            .or_default()
-            .push(l.larger);
+        adj.entry(l.smaller).or_default().push(l.larger);
     }
     // Run DFS detecting back-edges.
     let mut color: BTreeMap<NodeId, u8> = BTreeMap::new(); // 0=white,1=gray,2=black
@@ -1945,9 +1936,7 @@ pub fn cyclic(less: &[LessAtom]) -> bool {
 pub fn cyclic_with_path(less: &[LessAtom]) -> Vec<NodeId> {
     let mut adj: BTreeMap<NodeId, Vec<NodeId>> = BTreeMap::new();
     for l in less {
-        adj.entry(l.smaller)
-            .or_default()
-            .push(l.larger);
+        adj.entry(l.smaller).or_default().push(l.larger);
     }
     let mut color: BTreeMap<NodeId, u8> = BTreeMap::new();
     let mut path: Vec<NodeId> = Vec::new();

--- a/crates/tamarin-theory/src/constraint/solver/contradictions.rs
+++ b/crates/tamarin-theory/src/constraint/solver/contradictions.rs
@@ -2419,10 +2419,8 @@ mod tests {
         let pub_var = LVar::new("x", LSort::Pub, 58);
         let fresh_var = LVar::new("x", LSort::Fresh, 58);
         let tag = FactTag::Proto(Multiplicity::Linear, "X", 1);
-        let pub_term =
-            tamarin_term::term::Term::Lit(tamarin_term::vterm::Lit::Var(pub_var));
-        let fresh_term =
-            tamarin_term::term::Term::Lit(tamarin_term::vterm::Lit::Var(fresh_var));
+        let pub_term = tamarin_term::term::Term::Lit(tamarin_term::vterm::Lit::Var(pub_var));
+        let fresh_term = tamarin_term::term::Term::Lit(tamarin_term::vterm::Lit::Var(fresh_var));
         let mk_rule = |name: &str, t| -> RuleACInst {
             Rule::new(
                 RuleInfo::<ProtoRuleACInstInfo, IntrRuleACInfo>::Proto(ProtoRuleACInstInfo {

--- a/crates/tamarin-theory/src/constraint/solver/contradictions.rs
+++ b/crates/tamarin-theory/src/constraint/solver/contradictions.rs
@@ -106,11 +106,11 @@ pub fn contradictions(_ctxt: &ProofContext, sys: &System) -> Vec<Contradiction> 
     use tamarin_term::vterm::Lit;
     let subst = &sys.eq_store.subst;
     let resolve = |v: &LVar| -> LVar {
-        let t = tamarin_term::subst::apply_vterm(subst, Term::Lit(Lit::Var(v.clone())));
+        let t = tamarin_term::subst::apply_vterm(subst, Term::Lit(Lit::Var(*v)));
         if let Term::Lit(Lit::Var(w)) = t {
             w
         } else {
-            v.clone()
+            *v
         }
     };
     let mut all_less: Vec<LessAtom> = sys
@@ -823,7 +823,7 @@ fn has_forbidden_chain(sys: &System, ab_adj: &crate::constraint::system::Prebuil
                     Some(h) => h,
                     None => continue,
                 };
-                by_head.entry(head).or_default().push(v.clone());
+                by_head.entry(head).or_default().push(*v);
             }
             for (_, vars) in by_head {
                 if vars.len() < 2 {
@@ -835,9 +835,9 @@ fn has_forbidden_chain(sys: &System, ab_adj: &crate::constraint::system::Prebuil
                             continue;
                         }
                         equivalence_classes
-                            .entry(vi.clone())
+                            .entry(*vi)
                             .or_default()
-                            .insert(vj.clone());
+                            .insert(*vj);
                     }
                 }
             }
@@ -901,22 +901,22 @@ fn has_forbidden_chain(sys: &System, ab_adj: &crate::constraint::system::Prebuil
             continue;
         }
         let t_start_var = match t_start {
-            Term::Lit(Lit::Var(v)) => v.clone(),
+            Term::Lit(Lit::Var(v)) => *v,
             _ => continue,
         };
         // Build the set of candidate-equal Msg-Vars: t_start itself
         // plus any var in its disj-equivalence class.
         let mut candidate_vars: tamarin_utils::FastSet<tamarin_term::lterm::LVar> =
             tamarin_utils::FastSet::default();
-        candidate_vars.insert(t_start_var.clone());
+        candidate_vars.insert(t_start_var);
         if let Some(eqs) = equivalence_classes.get(&t_start_var) {
             for v in eqs {
-                candidate_vars.insert(v.clone());
+                candidate_vars.insert(*v);
             }
         }
         let candidate_terms: Vec<tamarin_term::lterm::LNTerm> = candidate_vars
             .iter()
-            .map(|v| Term::Lit(Lit::Var(v.clone())))
+            .map(|v| Term::Lit(Lit::Var(*v)))
             .collect();
         // (3) Some KU(t_start) action node precedes the chain
         // start `c.0`.  HS-faithful: `allKUActions` (System.hs:1582-1585)
@@ -1057,7 +1057,7 @@ fn has_forbidden_exp(sys: &System, ab_adj: &crate::constraint::system::PrebuiltA
         if let crate::constraint::constraints::Goal::Action(i, fa) = g {
             if matches!(fa.tag, FactTag::Ku) {
                 if let Some(m) = fa.terms.first() {
-                    all_ku.push((i.clone(), m.clone()));
+                    all_ku.push((*i, m.clone()));
                 }
             }
         }
@@ -1066,7 +1066,7 @@ fn has_forbidden_exp(sys: &System, ab_adj: &crate::constraint::system::PrebuiltA
         for fa in &rule.actions {
             if matches!(fa.tag, FactTag::Ku) {
                 if let Some(m) = fa.terms.first() {
-                    all_ku.push((id.clone(), m.clone()));
+                    all_ku.push((*id, m.clone()));
                 }
             }
         }
@@ -1139,7 +1139,7 @@ fn has_forbidden_exp(sys: &System, ab_adj: &crate::constraint::system::PrebuiltA
             let mvs = earlier_msg_vars();
             // `varTerm <$> frees g` then keep only MsgVars.
             for v in frees(g) {
-                let vt: LNTerm = Term::Lit(Lit::Var(v.clone()));
+                let vt: LNTerm = Term::Lit(Lit::Var(v));
                 if !is_msg_var(&vt) {
                     continue;
                 }
@@ -1324,7 +1324,7 @@ fn is_forbidden_d_emap(
     // the dExp's first premise (the dEMap rule).
     let edge_ns = sys.edges.iter().find_map(|e| {
         if e.tgt.0 == *i && e.tgt.1 == PremIdx(0) {
-            Some(e.src.0.clone())
+            Some(e.src.0)
         } else {
             None
         }
@@ -1471,7 +1471,7 @@ fn is_forbidden_d_emap_order(
      -> Option<crate::constraint::constraints::NodeId> {
         sys.edges.iter().find_map(|e| {
             if e.tgt.0 == *k && e.tgt.1 == pi {
-                Some(e.src.0.clone())
+                Some(e.src.0)
             } else {
                 None
             }
@@ -1517,9 +1517,9 @@ fn is_forbidden_d_emap_order(
     >|
      -> Vec<Vec<crate::fact::FactTag>> {
         vec![
-            r.premises.iter().map(|f| f.tag.clone()).collect(),
-            r.conclusions.iter().map(|f| f.tag.clone()).collect(),
-            r.actions.iter().map(|f| f.tag.clone()).collect(),
+            r.premises.iter().map(|f| f.tag).collect(),
+            r.conclusions.iter().map(|f| f.tag).collect(),
+            r.actions.iter().map(|f| f.tag).collect(),
         ]
     };
     tags_of(rp1) > tags_of(rp2)
@@ -1645,7 +1645,7 @@ fn non_injective_fact_instances(
         }
         // Strictly-reachable set (seed removed) via the shared routine.
         let out = crate::constraint::solver::goals::reachable_set_adj(adj, from, false);
-        reach_cache.borrow_mut().insert(from.clone(), out.clone());
+        reach_cache.borrow_mut().insert(*from, out.clone());
         out
     };
     // Resolve node-id → rule via a once-built map instead of a linear
@@ -1655,8 +1655,8 @@ fn non_injective_fact_instances(
         |id: &NodeId| -> Option<&crate::rule::RuleACInst> { node_rule_map.get(id).copied() };
 
     for e in &sys.edges {
-        let (i, conc_idx) = (e.src.0.clone(), e.src.1);
-        let k = e.tgt.0.clone();
+        let (i, conc_idx) = (e.src.0, e.src.1);
+        let k = e.tgt.0;
         // Look up the conclusion fact at (i, conc_idx).
         let i_rule = match lookup_node(&i) {
             Some(r) => r,
@@ -1698,9 +1698,9 @@ fn non_injective_fact_instances(
             let k_is_last = sys.last_atom.as_ref() == Some(&k);
             if k_after_j || k_is_last {
                 out.push(Contradiction::NonInjectiveFactInstance(
-                    i.clone(),
-                    j.clone(),
-                    k.clone(),
+                    i,
+                    *j,
+                    k,
                 ));
             }
         }
@@ -1898,9 +1898,9 @@ pub fn cyclic(less: &[LessAtom]) -> bool {
     // Build adjacency list keyed by NodeId.
     let mut adj: BTreeMap<NodeId, Vec<NodeId>> = BTreeMap::new();
     for l in less {
-        adj.entry(l.smaller.clone())
+        adj.entry(l.smaller)
             .or_default()
-            .push(l.larger.clone());
+            .push(l.larger);
     }
     // Run DFS detecting back-edges.
     let mut color: BTreeMap<NodeId, u8> = BTreeMap::new(); // 0=white,1=gray,2=black
@@ -1915,7 +1915,7 @@ pub fn cyclic(less: &[LessAtom]) -> bool {
             2 => return false, // already explored
             _ => {}
         }
-        color.insert(node.clone(), 1);
+        color.insert(*node, 1);
         if let Some(succs) = adj.get(node) {
             for s in succs {
                 if dfs(s, adj, color) {
@@ -1923,7 +1923,7 @@ pub fn cyclic(less: &[LessAtom]) -> bool {
                 }
             }
         }
-        color.insert(node.clone(), 2);
+        color.insert(*node, 2);
         false
     }
     for n in &nodes {
@@ -1945,9 +1945,9 @@ pub fn cyclic(less: &[LessAtom]) -> bool {
 pub fn cyclic_with_path(less: &[LessAtom]) -> Vec<NodeId> {
     let mut adj: BTreeMap<NodeId, Vec<NodeId>> = BTreeMap::new();
     for l in less {
-        adj.entry(l.smaller.clone())
+        adj.entry(l.smaller)
             .or_default()
-            .push(l.larger.clone());
+            .push(l.larger);
     }
     let mut color: BTreeMap<NodeId, u8> = BTreeMap::new();
     let mut path: Vec<NodeId> = Vec::new();
@@ -1959,12 +1959,12 @@ pub fn cyclic_with_path(less: &[LessAtom]) -> Vec<NodeId> {
         path: &mut Vec<NodeId>,
     ) -> Option<NodeId> {
         match color.get(node).copied().unwrap_or(0) {
-            1 => return Some(node.clone()), // back-edge target
+            1 => return Some(*node), // back-edge target
             2 => return None,
             _ => {}
         }
-        color.insert(node.clone(), 1);
-        path.push(node.clone());
+        color.insert(*node, 1);
+        path.push(*node);
         if let Some(succs) = adj.get(node) {
             for s in succs {
                 if let Some(target) = dfs(s, adj, color, path) {
@@ -1972,7 +1972,7 @@ pub fn cyclic_with_path(less: &[LessAtom]) -> Vec<NodeId> {
                 }
             }
         }
-        color.insert(node.clone(), 2);
+        color.insert(*node, 2);
         path.pop();
         None
     }
@@ -2000,7 +2000,7 @@ pub fn cyclic_with_path(less: &[LessAtom]) -> Vec<NodeId> {
 /// to prune typing-class source cases at precompute.
 fn node_after_last(sys: &System, adj: &BTreeMap<NodeId, Vec<NodeId>>) -> Vec<Contradiction> {
     let last = match &sys.last_atom {
-        Some(l) => l.clone(),
+        Some(l) => *l,
         None => return Vec::new(),
     };
     // Port of Haskell `Theory.Constraint.Solver.Contradictions.nodesAfterLast`:
@@ -2025,15 +2025,15 @@ fn node_after_last(sys: &System, adj: &BTreeMap<NodeId, Vec<NodeId>>) -> Vec<Con
     // isInTrace: collect every node-id that is "in the trace".
     let mut in_trace: BTreeSet<NodeId> = BTreeSet::new();
     for (id, _) in sys.nodes.iter() {
-        in_trace.insert(id.clone());
+        in_trace.insert(*id);
     }
-    in_trace.insert(last.clone()); // isLast is true for `last`
+    in_trace.insert(last); // isLast is true for `last`
     for (g, st) in sys.goals.iter() {
         if st.solved {
             continue;
         }
         if let crate::constraint::constraints::Goal::Action(id, _) = g {
-            in_trace.insert(id.clone());
+            in_trace.insert(*id);
         }
     }
     // Strictly-reachable set from `last` (seed removed) via the shared routine.
@@ -2041,7 +2041,7 @@ fn node_after_last(sys: &System, adj: &BTreeMap<NodeId, Vec<NodeId>>) -> Vec<Con
     visited
         .into_iter()
         .filter(|n| in_trace.contains(n))
-        .map(|after| Contradiction::NodeAfterLast(last.clone(), after))
+        .map(|after| Contradiction::NodeAfterLast(last, after))
         .collect()
 }
 

--- a/crates/tamarin-theory/src/constraint/solver/contradictions.rs
+++ b/crates/tamarin-theory/src/constraint/solver/contradictions.rs
@@ -2319,7 +2319,7 @@ mod tests {
 
         // Build the rule instances.
         let inj_tag = FactTag::Proto(Multiplicity::Linear, "Inj", 1);
-        let inj_fact = Fact::new(inj_tag.clone(), vec![msg_var("x", 0)]);
+        let inj_fact = Fact::new(inj_tag, vec![msg_var("x", 0)]);
 
         let init: RuleACInst = Rule::new(
             RuleInfo::<ProtoRuleACInstInfo, IntrRuleACInfo>::Proto(ProtoRuleACInstInfo {
@@ -2358,17 +2358,17 @@ mod tests {
         let j = n("3");
         let k = n("2");
         let mut sys = System::empty();
-        sys.add_node(i.clone(), init);
-        sys.add_node(j.clone(), copy);
-        sys.add_node(k.clone(), stop);
+        sys.add_node(i, init);
+        sys.add_node(j, copy);
+        sys.add_node(k, stop);
         // i → k edge (Inj fact).
         sys.add_edge(Edge {
-            src: (i.clone(), ConcIdx(0)),
-            tgt: (k.clone(), PremIdx(0)),
+            src: (i, ConcIdx(0)),
+            tgt: (k, PremIdx(0)),
         });
         // i < j, j < k via less atoms.
-        sys.add_less(LessAtom::new(i.clone(), j.clone(), Reason::Adversary));
-        sys.add_less(LessAtom::new(j.clone(), k.clone(), Reason::Adversary));
+        sys.add_less(LessAtom::new(i, j, Reason::Adversary));
+        sys.add_less(LessAtom::new(j, k, Reason::Adversary));
 
         // Build the proof context that knows `Inj` is injective.
         fn maude_path() -> Option<String> {
@@ -2388,7 +2388,7 @@ mod tests {
         };
         let h = MaudeHandle::start(&mp, tamarin_term::maude_sig::pair_maude_sig()).unwrap();
         let mut ctx = ProofContext::new(h, Vec::new());
-        ctx.injective_fact_insts = vec![(inj_tag.clone(), Vec::new())];
+        ctx.injective_fact_insts = vec![(inj_tag, Vec::new())];
 
         let cs = contradictions(&ctx, &sys);
         let injs: Vec<_> = cs
@@ -2420,9 +2420,9 @@ mod tests {
         let fresh_var = LVar::new("x", LSort::Fresh, 58);
         let tag = FactTag::Proto(Multiplicity::Linear, "X", 1);
         let pub_term =
-            tamarin_term::term::Term::Lit(tamarin_term::vterm::Lit::Var(pub_var.clone()));
+            tamarin_term::term::Term::Lit(tamarin_term::vterm::Lit::Var(pub_var));
         let fresh_term =
-            tamarin_term::term::Term::Lit(tamarin_term::vterm::Lit::Var(fresh_var.clone()));
+            tamarin_term::term::Term::Lit(tamarin_term::vterm::Lit::Var(fresh_var));
         let mk_rule = |name: &str, t| -> RuleACInst {
             Rule::new(
                 RuleInfo::<ProtoRuleACInstInfo, IntrRuleACInfo>::Proto(ProtoRuleACInstInfo {
@@ -2431,7 +2431,7 @@ mod tests {
                     loop_breakers: Vec::new(),
                 }),
                 vec![],
-                vec![Fact::new(tag.clone(), vec![t])],
+                vec![Fact::new(tag, vec![t])],
                 vec![],
             )
         };
@@ -2468,7 +2468,7 @@ mod tests {
                     loop_breakers: Vec::new(),
                 }),
                 vec![],
-                vec![Fact::new(tag.clone(), vec![t])],
+                vec![Fact::new(tag, vec![t])],
                 vec![],
             )
         };

--- a/crates/tamarin-theory/src/constraint/solver/goals.rs
+++ b/crates/tamarin-theory/src/constraint/solver/goals.rs
@@ -3046,9 +3046,9 @@ mod tests {
         let n: NodeId = LVar::new("i", LSort::Node, 0);
         let f: LNFact = LNFact::new(FactTag::Proto(Multiplicity::Linear, "F", 0), vec![]);
 
-        let action: Goal = Goal::Action(v.clone(), f.clone());
-        let chain: Goal = Goal::Chain((n.clone(), ConcIdx(0)), (n.clone(), PremIdx(0)));
-        let premise: Goal = Goal::Premise((n.clone(), PremIdx(0)), f.clone());
+        let action: Goal = Goal::Action(v, f.clone());
+        let chain: Goal = Goal::Chain((n, ConcIdx(0)), (n, PremIdx(0)));
+        let premise: Goal = Goal::Premise((n, PremIdx(0)), f.clone());
         let split: Goal = Goal::Split(SplitId(0));
         let disj: Goal = Goal::Disj(Disj::<crate::guarded::Guarded>::new(vec![]));
         // Use plain msg vars for the Subterm pair.
@@ -3131,9 +3131,9 @@ mod tests {
 
         // Build one of each variant in Haskell's declaration order.
         let variants = [
-            Goal::Action(v.clone(), f.clone()),
-            Goal::Chain((n.clone(), ConcIdx(0)), (n.clone(), PremIdx(0))),
-            Goal::Premise((n.clone(), PremIdx(0)), f.clone()),
+            Goal::Action(v, f.clone()),
+            Goal::Chain((n, ConcIdx(0)), (n, PremIdx(0))),
+            Goal::Premise((n, PremIdx(0)), f.clone()),
             Goal::Split(SplitId(0)),
             Goal::Disj(Disj::<crate::guarded::Guarded>::new(vec![])),
             Goal::Subterm((

--- a/crates/tamarin-theory/src/constraint/solver/goals.rs
+++ b/crates/tamarin-theory/src/constraint/solver/goals.rs
@@ -2666,14 +2666,14 @@ pub(crate) fn reachable_set_adj(
     use std::collections::{BTreeSet, VecDeque};
     let mut seen: BTreeSet<crate::constraint::constraints::NodeId> = BTreeSet::new();
     let mut q: VecDeque<crate::constraint::constraints::NodeId> = VecDeque::new();
-    q.push_back(from.clone());
+    q.push_back(*from);
     while let Some(n) = q.pop_front() {
-        if !seen.insert(n.clone()) {
+        if !seen.insert(n) {
             continue;
         }
         if let Some(succs) = adj.get(&n) {
             for s in succs {
-                q.push_back(s.clone());
+                q.push_back(*s);
             }
         }
     }

--- a/crates/tamarin-theory/src/constraint/solver/reduction.rs
+++ b/crates/tamarin-theory/src/constraint/solver/reduction.rs
@@ -8626,10 +8626,8 @@ mod tests {
             })
         };
         // First node has 0 conclusions; second has 1 — incompatible.
-        r.sys.add_node(
-            i,
-            crate::rule::Rule::new(info(), vec![], vec![], vec![]),
-        );
+        r.sys
+            .add_node(i, crate::rule::Rule::new(info(), vec![], vec![], vec![]));
         let dummy_fact = crate::fact::Fact::new(crate::fact::FactTag::Out, vec![]);
         r.sys.add_node(
             j,

--- a/crates/tamarin-theory/src/constraint/solver/reduction.rs
+++ b/crates/tamarin-theory/src/constraint/solver/reduction.rs
@@ -8504,8 +8504,8 @@ mod tests {
         use tamarin_term::vterm::Lit;
         let i = LVar::new("i", LSort::Node, 2);
         let j = LVar::new("j", LSort::Node, 3);
-        let ti = tamarin_term::term::Term::Lit(Lit::Var(i.clone()));
-        let tj = tamarin_term::term::Term::Lit(Lit::Var(j.clone()));
+        let ti = tamarin_term::term::Term::Lit(Lit::Var(i));
+        let tj = tamarin_term::term::Term::Lit(Lit::Var(j));
         // Add an edge i -> some target. (Source-only is enough — we
         // just want to verify the substitution propagates.)
         let tgt = LVar::new("t", LSort::Node, 99);
@@ -8514,8 +8514,8 @@ mod tests {
             .content_mut()
             .edges
             .push(crate::constraint::constraints::Edge {
-                src: (i.clone(), crate::rule::ConcIdx(0)),
-                tgt: (tgt.clone(), crate::rule::PremIdx(0)),
+                src: (i, crate::rule::ConcIdx(0)),
+                tgt: (tgt, crate::rule::PremIdx(0)),
             });
         // Inject the equality into the eq-store directly.
         r.solve_term_eqs(
@@ -8528,12 +8528,12 @@ mod tests {
         // mapped to whatever the canonical representative of i and j
         // is (the eq-store unifier picks one).
         let canonical = {
-            let id_term = tamarin_term::term::Term::Lit(Lit::Var(i.clone()));
+            let id_term = tamarin_term::term::Term::Lit(Lit::Var(i));
             let mapped = tamarin_term::subst::apply_vterm(&r.sys.eq_store.subst, id_term);
             if let tamarin_term::term::Term::Lit(Lit::Var(v)) = mapped {
                 v
             } else {
-                i.clone()
+                i
             }
         };
         assert_eq!(
@@ -8559,11 +8559,11 @@ mod tests {
             .content_mut()
             .less_atoms
             .push(crate::constraint::constraints::LessAtom::new(
-                i.clone(),
-                target.clone(),
+                i,
+                target,
                 crate::constraint::constraints::Reason::Formula,
             ));
-        let ti = tamarin_term::term::Term::Lit(Lit::Var(i.clone()));
+        let ti = tamarin_term::term::Term::Lit(Lit::Var(i));
         let tj = tamarin_term::term::Term::Lit(Lit::Var(j));
         r.solve_term_eqs(
             SplitStrategy::SplitNow,
@@ -8574,12 +8574,12 @@ mod tests {
         // The less atom's `smaller` should still resolve to the same
         // canonical id reachable from i via the eq-store.
         let canonical = {
-            let id_term = tamarin_term::term::Term::Lit(Lit::Var(i.clone()));
+            let id_term = tamarin_term::term::Term::Lit(Lit::Var(i));
             let mapped = tamarin_term::subst::apply_vterm(&r.sys.eq_store.subst, id_term);
             if let tamarin_term::term::Term::Lit(Lit::Var(v)) = mapped {
                 v
             } else {
-                i.clone()
+                i
             }
         };
         assert_eq!(r.sys.less_atoms[0].smaller, canonical);
@@ -8627,12 +8627,12 @@ mod tests {
         };
         // First node has 0 conclusions; second has 1 — incompatible.
         r.sys.add_node(
-            i.clone(),
+            i,
             crate::rule::Rule::new(info(), vec![], vec![], vec![]),
         );
         let dummy_fact = crate::fact::Fact::new(crate::fact::FactTag::Out, vec![]);
         r.sys.add_node(
-            j.clone(),
+            j,
             crate::rule::Rule::new(info(), vec![], vec![dummy_fact], vec![]),
         );
         // Force i = j into the eq-store.
@@ -8679,8 +8679,8 @@ mod tests {
             actions: vec![],
             new_vars: vec![],
         };
-        r.sys.add_node(i.clone(), ru());
-        r.sys.add_node(j.clone(), ru());
+        r.sys.add_node(i, ru());
+        r.sys.add_node(j, ru());
         let ti = tamarin_term::term::Term::Lit(Lit::Var(i));
         let tj = tamarin_term::term::Term::Lit(Lit::Var(j));
         r.solve_term_eqs(
@@ -8862,8 +8862,8 @@ mod tests {
             vec![],
             vec![fa.clone()],
         );
-        sys.add_node(i.clone(), ru);
-        sys.add_goal(Goal::Action(i.clone(), fa.clone()));
+        sys.add_node(i, ru);
+        sys.add_goal(Goal::Action(i, fa.clone()));
         let mut r = Reduction::new(&ctx, sys);
         let out = r.solve_action_goal(&i, &fa);
         // Post-Root-D: `LinearNamed(rule_case_name)`. The case name must
@@ -9010,7 +9010,7 @@ mod tests {
         let v2 = tamarin_term::lterm::LVar::new("x", tamarin_term::lterm::LSort::Msg, 0);
         let tx: tamarin_term::lterm::LNTerm = tamarin_term::term::Term::Lit(Lit::Var(v2));
         let fa = crate::fact::out_fact(tx);
-        let p = (i.clone(), crate::rule::PremIdx(0));
+        let p = (i, crate::rule::PremIdx(0));
         let out = r.solve_premise_goal(&p, &fa);
         // Single matching rule → LinearNamed("Producer"); node + edge
         // applied in-place to r.sys.
@@ -9091,7 +9091,7 @@ mod tests {
             vec![conc_kd],
             vec![],
         );
-        sys.add_node(i.clone(), ru_i);
+        sys.add_node(i, ru_i);
         // Node j premise: KD(x).
         let prem_kd = crate::fact::kd_fact(tx);
         let ru_j: crate::rule::RuleACInst = crate::rule::Rule::new(
@@ -9100,10 +9100,10 @@ mod tests {
             vec![],
             vec![],
         );
-        sys.add_node(j.clone(), ru_j);
+        sys.add_node(j, ru_j);
         let c = (i, crate::rule::ConcIdx(0));
         let p = (j, crate::rule::PremIdx(0));
-        sys.add_goal(Goal::Chain(c.clone(), p.clone()));
+        sys.add_goal(Goal::Chain(c, p));
         let mut r = Reduction::new(&ctx, sys);
         let out = r.solve_chain_goal(&c, &p);
         // Compatible facts → LinearNamed (rule-named) with edge added

--- a/crates/tamarin-theory/src/constraint/solver/reduction.rs
+++ b/crates/tamarin-theory/src/constraint/solver/reduction.rs
@@ -596,7 +596,7 @@ impl<'ctx> Reduction<'ctx> {
         &mut self,
         i: crate::constraint::constraints::NodeId,
     ) -> Result<SolveOutcome, crate::tools::equation_store::AddEqsError> {
-        match self.sys.last_atom.clone() {
+        match self.sys.last_atom {
             None => {
                 // Pure ADD (last_atom None→Some): the max can only rise
                 // by this node id — bump instead of invalidating.
@@ -834,7 +834,7 @@ impl<'ctx> Reduction<'ctx> {
             // result `apply_vterm` gives on a `Lit::Var` term, minus the
             // temporary term construction.
             match subst_view.image_of(&v) {
-                Some(tamarin_term::term::Term::Lit(tamarin_term::vterm::Lit::Var(w))) => w.clone(),
+                Some(tamarin_term::term::Term::Lit(tamarin_term::vterm::Lit::Var(w))) => *w,
                 _ => v,
             }
         };
@@ -860,7 +860,7 @@ impl<'ctx> Reduction<'ctx> {
         // disjoint 2-unifier (→ deferred `splitEqs`) instead of HS's shared
         // 1-unifier (→ direct `by contradiction`).  Sort by node-id here to
         // mirror `M.toList`, so the live/lower-idx node's rule survives.
-        nodes.sort_by(|a, b| a.0.cmp(&b.0));
+        nodes.sort_by_key(|a| a.0);
         let mut new_nodes: Vec<(crate::constraint::constraints::NodeId, RuleACInst)> =
             Vec::with_capacity(nodes.len());
         let mut id_to_index: tamarin_utils::FastMap<crate::constraint::constraints::NodeId, usize> =
@@ -938,7 +938,7 @@ impl<'ctx> Reduction<'ctx> {
                 // Subst rebuild — frees change; the computing constructor
                 // recomputes the bloom from the post-subst terms internally
                 // (never copy `fa`'s bloom: the rebuild changes the free-var set).
-                crate::fact::LNFact::fresh_annotated(fa.tag.clone(), fa.annotations.clone(), terms)
+                crate::fact::LNFact::fresh_annotated(fa.tag, fa.annotations.clone(), terms)
             })
         };
         let dbg_set_nodes = tamarin_utils::env_gate!("TAM_DBG_SET_NODES");
@@ -973,7 +973,7 @@ impl<'ctx> Reduction<'ctx> {
         let mut id_renamed_nodes: Vec<(crate::constraint::constraints::NodeId, RuleACInst)> =
             Vec::new();
         for (id, rule) in nodes {
-            let id_orig = id.clone();
+            let id_orig = id;
             let new_id = map_var(id);
             if new_id != id_orig {
                 nodes_value_changed = true;
@@ -1047,7 +1047,7 @@ impl<'ctx> Reduction<'ctx> {
                     }
                 }
                 None => {
-                    id_to_index.insert(new_id.clone(), new_nodes.len());
+                    id_to_index.insert(new_id, new_nodes.len());
                     new_nodes.push((new_id, rule));
                 }
             }
@@ -1157,12 +1157,12 @@ impl<'ctx> Reduction<'ctx> {
         // change the max free-var idx.
         let mut edges_value_changed = false;
         for e in self.sys.content_mut_untracked().edges.iter_mut() {
-            let new_src = map_var(e.src.0.clone());
+            let new_src = map_var(e.src.0);
             if new_src != e.src.0 {
                 edges_value_changed = true;
                 e.src.0 = new_src;
             }
-            let new_tgt = map_var(e.tgt.0.clone());
+            let new_tgt = map_var(e.tgt.0);
             if new_tgt != e.tgt.0 {
                 edges_value_changed = true;
                 e.tgt.0 = new_tgt;
@@ -1182,7 +1182,7 @@ impl<'ctx> Reduction<'ctx> {
         // 3. Last-atom.
         let mut last_atom_changed = false;
         if let Some(last) = self.sys.content_mut_untracked().last_atom.take() {
-            let new_last = map_var(last.clone());
+            let new_last = map_var(last);
             if new_last != last {
                 last_atom_changed = true;
                 self.sys.invalidate_max_var_idx_cache();
@@ -1232,17 +1232,17 @@ impl<'ctx> Reduction<'ctx> {
         let mut less_value_changed = false;
         for la in std::mem::take(&mut self.sys.content_mut_untracked().less_atoms) {
             let mut la = la;
-            let new_smaller = map_var(la.smaller.clone());
+            let new_smaller = map_var(la.smaller);
             if new_smaller != la.smaller {
                 less_value_changed = true;
                 la.smaller = new_smaller;
             }
-            let new_larger = map_var(la.larger.clone());
+            let new_larger = map_var(la.larger);
             if new_larger != la.larger {
                 less_value_changed = true;
                 la.larger = new_larger;
             }
-            if seen_less.insert((la.smaller.clone(), la.larger.clone())) {
+            if seen_less.insert((la.smaller, la.larger)) {
                 new_less.push(la);
             }
         }
@@ -1342,7 +1342,7 @@ impl<'ctx> Reduction<'ctx> {
                 match subst.image_of(&v) {
                     Some(tamarin_term::term::Term::Lit(tamarin_term::vterm::Lit::Var(w))) => {
                         goals_value_changed.set(true);
-                        w.clone()
+                        *w
                     }
                     _ => v,
                 }
@@ -1499,7 +1499,7 @@ impl<'ctx> Reduction<'ctx> {
             };
             if needs_reinsert {
                 if let Goal::Action(i, fa) = &g2 {
-                    to_insert_action.push((i.clone(), fa.clone(), st.clone()));
+                    to_insert_action.push((*i, fa.clone(), st.clone()));
                 }
             } else {
                 // HS-faithful merge: mirror `M.insertWith combineGoalStatus`
@@ -2025,7 +2025,7 @@ impl<'ctx> Reduction<'ctx> {
                     let mut sys_vars: std::collections::BTreeSet<tamarin_term::lterm::LVar> =
                         std::collections::BTreeSet::new();
                     let mut visit = |v: &tamarin_term::lterm::LVar| {
-                        sys_vars.insert(v.clone());
+                        sys_vars.insert(*v);
                     };
                     for (id, rule) in self.sys.nodes.iter() {
                         id.for_each_free(&mut visit);
@@ -2176,7 +2176,7 @@ impl<'ctx> Reduction<'ctx> {
                         if self.sys.goals.iter().any(|(eg, _)| eg == &g) {
                             return;
                         }
-                        let outer_node = node_id.clone();
+                        let outer_node = *node_id;
                         // HS-faithful order (Reduction.hs:364-366):
                         //   insertGoal goal False                     -- outer FIRST
                         //   requiresKU m1 *> requiresKU m2 ...        -- sub-goals after
@@ -2226,12 +2226,12 @@ impl<'ctx> Reduction<'ctx> {
                             }
                             let sub_fa = crate::fact::ku_fact(sub);
                             self.insert_goal_with_loop_flag(
-                                Goal::Action(sub_node.clone(), sub_fa),
+                                Goal::Action(sub_node, sub_fa),
                                 looping,
                             );
                             self.insert_less(crate::constraint::constraints::LessAtom::new(
                                 sub_node,
-                                outer_node.clone(),
+                                outer_node,
                                 crate::constraint::constraints::Reason::Adversary,
                             ));
                         }
@@ -2858,7 +2858,7 @@ impl<'ctx> Reduction<'ctx> {
                                 .push(std::sync::Arc::new(g.clone()));
                         }
                         let last_node = match &self.sys.last_atom {
-                            Some(j) => j.clone(),
+                            Some(j) => *j,
                             None => {
                                 let baseline = self.fresh_var_baseline();
                                 let j = tamarin_term::lterm::LVar::new(
@@ -2867,7 +2867,7 @@ impl<'ctx> Reduction<'ctx> {
                                     baseline.saturating_add(1),
                                 );
                                 self.sys.invalidate_max_var_idx_cache();
-                                self.sys.set_last_atom(Some(j.clone()));
+                                self.sys.set_last_atom(Some(j));
                                 j
                             }
                         };
@@ -3331,8 +3331,8 @@ impl<'ctx> Reduction<'ctx> {
         let term_eqs: Vec<tamarin_term::rewriting::Equal<tamarin_term::lterm::LNTerm>> = eqs
             .iter()
             .map(|e| tamarin_term::rewriting::Equal {
-                lhs: Term::Lit(Lit::Var(e.lhs.clone())),
-                rhs: Term::Lit(Lit::Var(e.rhs.clone())),
+                lhs: Term::Lit(Lit::Var(e.lhs)),
+                rhs: Term::Lit(Lit::Var(e.rhs)),
             })
             .collect();
         self.solve_term_eqs(SplitStrategy::SplitNow, &term_eqs)
@@ -3533,7 +3533,7 @@ impl<'ctx> Reduction<'ctx> {
         let mut order: Vec<crate::constraint::constraints::NodeId> = Vec::new();
         for (id, ru) in nodes {
             if !groups.contains_key(&id) {
-                order.push(id.clone());
+                order.push(id);
             }
             groups.entry(id).or_default().push(ru);
         }
@@ -3771,7 +3771,7 @@ impl<'ctx> Reduction<'ctx> {
         // 4. insertLast: HS-faithful (Reduction.hs:402-407 + conjoinSystem
         // Reduction.hs:669-698, see line 676 `F.mapM_ insertLast $ get sLastAtom sys`).
         if let Some(case_last) = &sys.last_atom {
-            let r = self.insert_last(case_last.clone());
+            let r = self.insert_last(*case_last);
             if matches!(r, Err(_) | Ok(SolveOutcome::Contradictory)) {
                 return r;
             }
@@ -4031,7 +4031,7 @@ fn canonical_rule_inst(o: &crate::theory::OpenProtoRule) -> RuleACInst {
     let src: &crate::rule::ProtoRuleE = o.abstracted_rule.as_ref().unwrap_or(&o.rule);
     crate::rule::Rule {
         info: crate::rule::RuleInfo::Proto(crate::rule::ProtoRuleACInstInfo {
-            name: src.info.name.clone(),
+            name: src.info.name,
             attributes: src.info.attributes.clone(),
             loop_breakers: o.loop_breakers.clone(),
         }),
@@ -4226,7 +4226,7 @@ fn build_parser_subst_from_eq_store(
     // `structural_match` fails and `impliedFormulas` misses the
     // discharge, leaving FormulasFalse unfired — wrong-Solved.
     let lookup_chain = |start: &tamarin_term::lterm::LVar| -> tamarin_term::lterm::LNTerm {
-        let mut cur = tamarin_term::term::Term::Lit(tamarin_term::vterm::Lit::Var(start.clone()));
+        let mut cur = tamarin_term::term::Term::Lit(tamarin_term::vterm::Lit::Var(*start));
         // Bound chain length to avoid pathological cycles (shouldn't
         // happen post-compose, but defensive).  Borrowing COW step: the
         // helper returns `None` exactly when applying `subst` leaves `cur`
@@ -4287,7 +4287,7 @@ fn normalise_node_id(
     id: crate::constraint::constraints::NodeId,
     subst: &crate::tools::equation_store::LNSubst,
 ) -> crate::constraint::constraints::NodeId {
-    let id_term = tamarin_term::term::Term::Lit(tamarin_term::vterm::Lit::Var(id.clone()));
+    let id_term = tamarin_term::term::Term::Lit(tamarin_term::vterm::Lit::Var(id));
     let mapped = tamarin_term::subst::apply_vterm(subst, id_term);
     if let tamarin_term::term::Term::Lit(tamarin_term::vterm::Lit::Var(v)) = mapped {
         v
@@ -5165,7 +5165,7 @@ fn collect_live_system_vars(sys: &System) -> std::collections::BTreeSet<tamarin_
     use tamarin_term::lterm::HasFrees;
     let mut s = std::collections::BTreeSet::new();
     let mut visit = |v: &tamarin_term::lterm::LVar| {
-        s.insert(v.clone());
+        s.insert(*v);
     };
     for (id, rule) in sys.nodes.iter() {
         id.for_each_free(&mut visit);
@@ -5453,7 +5453,7 @@ fn subterm_step(
                 Err(_) => None,
                 Ok((n_small, n_big)) => {
                     let new_var = mk_fresh(sort_of_lnterm(big));
-                    let small_plus = f_app_ac(f, vec![n_small, var_term(new_var.clone())]);
+                    let small_plus = f_app_ac(f, vec![n_small, var_term(new_var)]);
                     let mut out: Vec<SubtermSplit> = Vec::new();
                     out.push(SubtermSplit::AcNewVarD(small_plus, n_big, new_var));
                     // map (curry SubtermD small) (flattenedACTerms f big)
@@ -5516,7 +5516,7 @@ fn close_guarded_ex_eq(
     r: &tamarin_term::lterm::LNTerm,
 ) -> crate::guarded::Guarded {
     let var_lt: tamarin_term::lterm::LNTerm =
-        tamarin_term::term::Term::Lit(tamarin_term::vterm::Lit::Var(new_var.clone()));
+        tamarin_term::term::Term::Lit(tamarin_term::vterm::Lit::Var(*new_var));
     let vs = match crate::elaborate::lnterm_to_term(&var_lt) {
         tamarin_parser::ast::Term::Var(v) => v,
         _ => unreachable!("var_term elaborates to a Var"),
@@ -5596,7 +5596,7 @@ fn has_fresh_consumer_conflation(
             let t_norm = tamarin_term::subst::apply_vterm(subst, t.clone());
             if let Term::Lit(Lit::Var(v)) = t_norm {
                 if v.sort == LSort::Fresh {
-                    consumers.push((id.clone(), v, rule));
+                    consumers.push((*id, v, rule));
                 }
             }
         }
@@ -6074,7 +6074,7 @@ impl<'ctx> Reduction<'ctx> {
             // (v `elem` breakers)`).  Covers Kd/Ded and every other tag.
             _ => {
                 self.insert_goal_with_loop_flag(
-                    Goal::Premise((i.clone(), idx), fa.clone()),
+                    Goal::Premise((*i, idx), fa.clone()),
                     is_loop_breaker,
                 );
             }
@@ -6129,7 +6129,7 @@ impl<'ctx> Reduction<'ctx> {
                 path, next
             );
         }
-        self.sys.add_node(j.clone(), rule);
+        self.sys.add_node(j, rule);
         // HS-faithful (Reduction.hs:217-270, see line 258): `exploitPrem FreshFact` does
         // a raw `modM sEdges (S.insert $ Edge (j, ConcIdx 0) (i,v))` —
         // NO `insertEdges` (so NO solveFactEqs).  Routing through
@@ -6147,7 +6147,7 @@ impl<'ctx> Reduction<'ctx> {
         // `add_isend_supplier_for` path and avoids a full cache recompute.
         self.sys.add_edge(crate::constraint::constraints::Edge {
             src: (j, crate::rule::ConcIdx(0)),
-            tgt: (i.clone(), idx),
+            tgt: (*i, idx),
         });
         // Haskell `unless (isFreshVar m)`: narrow m:Msg → ~n:Fresh
         // via solveTermEqs.  Only fires when m is not already Fresh-
@@ -6173,7 +6173,7 @@ impl<'ctx> Reduction<'ctx> {
             let n_var =
                 tamarin_term::lterm::LVar::new("n", tamarin_term::lterm::LSort::Fresh, next_n);
             let n_term =
-                tamarin_term::term::Term::Lit(tamarin_term::vterm::Lit::Var(n_var.clone()));
+                tamarin_term::term::Term::Lit(tamarin_term::vterm::Lit::Var(n_var));
             crate::constraint::solver::trace::trace_exec("FrNarrow");
             if tamarin_utils::env_gate!("TAM_RS_TRACE_FR_NARROW") {
                 eprintln!(
@@ -6251,14 +6251,14 @@ impl<'ctx> Reduction<'ctx> {
                 crate::constraint::solver::reduction::rule_trace_name(&rule)
             ));
         }
-        self.sys.add_node(j.clone(), rule);
+        self.sys.add_node(j, rule);
         // HS-faithful (Reduction.hs:217-270, see line 247): `exploitPrem InFact` does a
         // RAW `modM sEdges (S.insert $ Edge (j, ConcIdx 0) (i, v))` —
         // NO `insertEdges` call, NO `solveFactEqs` unification, NO
         // `[EXEC] insertEdges n=1` trace.
         self.sys.add_edge(crate::constraint::constraints::Edge {
-            src: (j.clone(), crate::rule::ConcIdx(0)),
-            tgt: (i.clone(), idx),
+            src: (j, crate::rule::ConcIdx(0)),
+            tgt: (*i, idx),
         });
         // ISend's KU premise → KU action goal at fresh predecessor —
         // Haskell's `exploitPrems j ruKnows`.  Always record the goal,
@@ -6295,8 +6295,8 @@ impl<'ctx> Reduction<'ctx> {
             );
         }
         self.insert_less(crate::constraint::constraints::LessAtom::new(
-            j.clone(),
-            i.clone(),
+            j,
+            *i,
             crate::constraint::constraints::Reason::Adversary,
         ));
         self.insert_goal(Goal::Action(j, fa.clone()));
@@ -6371,7 +6371,7 @@ impl<'ctx> Reduction<'ctx> {
             "solveActionGoal"
         };
         let _op_guard = crate::constraint::solver::trace::OpLabelGuard::new(label);
-        let g = Goal::Action(i.clone(), fa.clone());
+        let g = Goal::Action(*i, fa.clone());
         let existing = self
             .sys
             .nodes
@@ -6544,7 +6544,7 @@ impl<'ctx> Reduction<'ctx> {
                         if case_pairs.is_empty() {
                             return GoalCases::Contradictory;
                         }
-                        let live_goal = Goal::Action(i.clone(), fa.clone());
+                        let live_goal = Goal::Action(*i, fa.clone());
                         let mut out: Vec<(String, crate::constraint::system::System)> = Vec::new();
                         // HS FreshT-threading (task #16): per-out-case branch counters.
                         let mut out_counters: Vec<u64> = Vec::new();
@@ -6664,7 +6664,7 @@ impl<'ctx> Reduction<'ctx> {
                             // re-narrows live disjunctions HS keeps).
                             let action_live_node_ids: std::collections::BTreeSet<
                                 crate::constraint::constraints::NodeId,
-                            > = self.sys.nodes.iter().map(|(n, _)| n.clone()).collect();
+                            > = self.sys.nodes.iter().map(|(n, _)| *n).collect();
                             'arm: for (arm_sys, arm_counter) in action_arm_systems {
                                 let mut sub =
                                     Reduction::new_inheriting(self.ctx, arm_sys, arm_counter);
@@ -6841,10 +6841,10 @@ impl<'ctx> Reduction<'ctx> {
                                     vec![fa.clone()],
                                     vec![fa.clone()],
                                 );
-                                sub.sys.add_node(i.clone(), coerce_ru);
+                                sub.sys.add_node(*i, coerce_ru);
                                 // PremiseG (i, PremIdx 0) (kdFact m)
                                 sub.insert_goal(Goal::Premise(
-                                    (i.clone(), crate::rule::PremIdx(0)),
+                                    (*i, crate::rule::PremIdx(0)),
                                     kd_m,
                                 ));
                                 let case_name = "coerce".to_string();
@@ -6880,7 +6880,7 @@ impl<'ctx> Reduction<'ctx> {
                                     vec![fa.clone()],
                                     vec![fa.clone()],
                                 );
-                                sub.sys.add_node(i.clone(), xor_ru);
+                                sub.sys.add_node(*i, xor_ru);
                                 // requiresKU a, requiresKU b
                                 sub.add_ku_action_before(i, &ku_a);
                                 sub.add_ku_action_before(i, &ku_b);
@@ -7004,7 +7004,7 @@ impl<'ctx> Reduction<'ctx> {
                         }
                         let case_name = rule_case_name(&renamed);
                         let mut sys = self.sys.clone();
-                        sys.add_node(i.clone(), renamed.clone());
+                        sys.add_node(*i, renamed.clone());
                         let mut sub = Reduction::new(self.ctx, sys);
                         // HS-faithful order (Goals.hs:262-265): `labelNodeId
                         // i rules Nothing` returns the chosen `ru` AFTER
@@ -7200,11 +7200,11 @@ impl<'ctx> Reduction<'ctx> {
                 vec![crate::fact::kd_fact(m_learn.clone())],
                 vec![],
             );
-            self.sys.add_node(i_learn.clone(), irecv_rule);
+            self.sys.add_node(i_learn, irecv_rule);
             let c_learn: crate::constraint::constraints::NodeConc =
-                (i_learn.clone(), crate::rule::ConcIdx(0));
-            self.insert_goal(Goal::Chain(c_learn, p.clone()));
-            self.mark_goal_as_solved(&Goal::Premise(p.clone(), fa_prem.clone()));
+                (i_learn, crate::rule::ConcIdx(0));
+            self.insert_goal(Goal::Chain(c_learn, *p));
+            self.mark_goal_as_solved(&Goal::Premise(*p, fa_prem.clone()));
             self.changed = ChangeIndicator::Changed;
             // Recurse on the Out(mLearn) premise — Haskell does this
             // immediately, inline, before any chain solving.  This is
@@ -7287,7 +7287,7 @@ impl<'ctx> Reduction<'ctx> {
                 // dropped — keeps the search making progress.
             }
         }
-        let g = Goal::Premise(p.clone(), fa_prem.clone());
+        let g = Goal::Premise(*p, fa_prem.clone());
         // Canonical (abstracted) rule + variant disjunction installed
         // as SplitG after labeling — Haskell-faithful `someRuleACInst`
         // path (Rule.hs:925-934, see line 933).
@@ -7374,7 +7374,7 @@ impl<'ctx> Reduction<'ctx> {
             // freshen counter), not a bounds_max re-derivation — see
             // `new_inheriting`.
             let mut label_sys = self.sys.clone();
-            label_sys.add_node(new_node.clone(), renamed.clone());
+            label_sys.add_node(new_node, renamed.clone());
             let mut label_sub =
                 Reduction::new_inheriting(self.ctx, label_sys, self.maude.fresh_counter_peek());
             if tamarin_utils::env_gate!("TAM_RS_DBG_SOLVE_RULE_CONSTRAINTS") {
@@ -7412,8 +7412,8 @@ impl<'ctx> Reduction<'ctx> {
                 let res = sub.insert_edge_labeled_with_facts(
                     "premise_goal_rule_enum",
                     crate::constraint::constraints::Edge {
-                        src: (new_node.clone(), c_idx),
-                        tgt: p.clone(),
+                        src: (new_node, c_idx),
+                        tgt: *p,
                     },
                     fa_conc,
                     fa_prem,
@@ -7525,7 +7525,7 @@ impl<'ctx> Reduction<'ctx> {
             };
             eprintln!("[SOLVE_CHAIN] enter mode={} c={:?} p={:?}", mode, c, p);
         }
-        let g = Goal::Chain(c.clone(), p.clone());
+        let g = Goal::Chain(*c, *p);
         let c_rule = match self.sys.nodes.iter().find(|(id, _)| id == &c.0) {
             Some((_, r)) => r.clone(),
             None => return GoalCases::Contradictory,
@@ -7588,8 +7588,8 @@ impl<'ctx> Reduction<'ctx> {
                     let res = sub.insert_edge_labeled(
                         "chain_direct",
                         crate::constraint::constraints::Edge {
-                            src: c.clone(),
-                            tgt: p.clone(),
+                            src: *c,
+                            tgt: *p,
                         },
                     );
                     if !matches!(res, Err(_) | Ok(SolveOutcome::Contradictory)) {
@@ -7716,7 +7716,7 @@ impl<'ctx> Reduction<'ctx> {
                 let new_node =
                     tamarin_term::lterm::LVar::new("vr", tamarin_term::lterm::LSort::Node, vr_idx);
                 let mut sys_clone = self.sys.clone();
-                sys_clone.add_node(new_node.clone(), ru_inst.clone());
+                sys_clone.add_node(new_node, ru_inst.clone());
                 let mut sub =
                     Reduction::new_inheriting(self.ctx, sys_clone, self.maude.fresh_counter_peek());
                 // HS `extendAndMark i ru v faPrem faConc` (Goals.hs `extendAndMark`):
@@ -7726,8 +7726,8 @@ impl<'ctx> Reduction<'ctx> {
                 let res = sub.insert_edge_labeled(
                     "chain_extend",
                     crate::constraint::constraints::Edge {
-                        src: c.clone(),
-                        tgt: (new_node.clone(), crate::rule::PremIdx(0)),
+                        src: *c,
+                        tgt: (new_node, crate::rule::PremIdx(0)),
                     },
                 );
                 if matches!(res, Err(_) | Ok(SolveOutcome::Contradictory)) {
@@ -7748,12 +7748,12 @@ impl<'ctx> Reduction<'ctx> {
                     let mut arm_sub =
                         Reduction::new_inheriting(self.ctx, arm_sys, post_edge_counter);
                     arm_sub.mark_goal_as_solved(&Goal::Premise(
-                        (new_node.clone(), crate::rule::PremIdx(0)),
+                        (new_node, crate::rule::PremIdx(0)),
                         prem0.clone(),
                     ));
                     arm_sub.insert_goal(Goal::Chain(
-                        (new_node.clone(), crate::rule::ConcIdx(0)),
-                        p.clone(),
+                        (new_node, crate::rule::ConcIdx(0)),
+                        *p,
                     ));
                     let arm_counter = arm_sub.maude.fresh_counter_peek();
                     arm_sys = arm_sub.sys;
@@ -7915,7 +7915,7 @@ impl<'ctx> Reduction<'ctx> {
                 let mut sys_clone = self.sys.clone();
                 let new_node =
                     tamarin_term::lterm::LVar::new("vr", tamarin_term::lterm::LSort::Node, vr_idx);
-                sys_clone.add_node(new_node.clone(), ru_renamed.clone());
+                sys_clone.add_node(new_node, ru_renamed.clone());
                 // HS FreshT-threading: continue the enclosing thread
                 // (post-freshen counter of THIS destructor fork).
                 let mut sub =
@@ -7961,8 +7961,8 @@ impl<'ctx> Reduction<'ctx> {
                 let res = sub.insert_edge_labeled(
                     "chain_extend",
                     crate::constraint::constraints::Edge {
-                        src: c.clone(),
-                        tgt: (new_node.clone(), crate::rule::PremIdx(0)),
+                        src: *c,
+                        tgt: (new_node, crate::rule::PremIdx(0)),
                     },
                 );
                 if tamarin_utils::env_gate!("TAM_RS_DBG_CHAIN_EXTEND_MULTI") {
@@ -8025,13 +8025,13 @@ impl<'ctx> Reduction<'ctx> {
                     let mut arm_sub =
                         Reduction::new_inheriting(self.ctx, arm_sys, post_edge_counter);
                     arm_sub.mark_goal_as_solved(&Goal::Premise(
-                        (new_node.clone(), crate::rule::PremIdx(0)),
+                        (new_node, crate::rule::PremIdx(0)),
                         prem0.clone(),
                     ));
                     // Insert the chain continuation (i, ConcIdx(0)) → p.
                     arm_sub.insert_goal(Goal::Chain(
-                        (new_node.clone(), crate::rule::ConcIdx(0)),
-                        p.clone(),
+                        (new_node, crate::rule::ConcIdx(0)),
+                        *p,
                     ));
                     let arm_counter = arm_sub.maude.fresh_counter_peek();
                     arm_sys = arm_sub.sys;
@@ -8192,7 +8192,7 @@ impl<'ctx> Reduction<'ctx> {
                         let new_var = LVar::new("newVar", LSort::Nat, sub.maude.fresh_idx());
                         // sPlus = s ++: varTerm newVar
                         let s_plus =
-                            f_app_ac(AcSym::NatPlus, vec![s.clone(), var_term(new_var.clone())]);
+                            f_app_ac(AcSym::NatPlus, vec![s.clone(), var_term(new_var)]);
                         // insertFormula $ closeGuarded Ex [newVar] [EqE sPlus t] gtrue
                         let f = close_guarded_ex_eq(&new_var, &s_plus, t);
                         sub.insert_formula(f);

--- a/crates/tamarin-theory/src/constraint/solver/reduction.rs
+++ b/crates/tamarin-theory/src/constraint/solver/reduction.rs
@@ -6042,7 +6042,7 @@ impl<'ctx> Reduction<'ctx> {
         // `looping=true`, so `isNonLoopBreakerProtoFactGoal` excludes
         // them and the smart ranker defers them.
         let breakers: std::collections::BTreeSet<crate::rule::PremIdx> = match &rule.info {
-            crate::rule::RuleInfo::Proto(info) => info.loop_breakers.iter().cloned().collect(),
+            crate::rule::RuleInfo::Proto(info) => info.loop_breakers.iter().copied().collect(),
             _ => std::collections::BTreeSet::new(),
         };
         for (idx, fa) in prems {

--- a/crates/tamarin-theory/src/constraint/solver/reduction.rs
+++ b/crates/tamarin-theory/src/constraint/solver/reduction.rs
@@ -6172,8 +6172,7 @@ impl<'ctx> Reduction<'ctx> {
             let next_n = bounds_max(&self.sys).saturating_add(1);
             let n_var =
                 tamarin_term::lterm::LVar::new("n", tamarin_term::lterm::LSort::Fresh, next_n);
-            let n_term =
-                tamarin_term::term::Term::Lit(tamarin_term::vterm::Lit::Var(n_var));
+            let n_term = tamarin_term::term::Term::Lit(tamarin_term::vterm::Lit::Var(n_var));
             crate::constraint::solver::trace::trace_exec("FrNarrow");
             if tamarin_utils::env_gate!("TAM_RS_TRACE_FR_NARROW") {
                 eprintln!(
@@ -6843,10 +6842,7 @@ impl<'ctx> Reduction<'ctx> {
                                 );
                                 sub.sys.add_node(*i, coerce_ru);
                                 // PremiseG (i, PremIdx 0) (kdFact m)
-                                sub.insert_goal(Goal::Premise(
-                                    (*i, crate::rule::PremIdx(0)),
-                                    kd_m,
-                                ));
+                                sub.insert_goal(Goal::Premise((*i, crate::rule::PremIdx(0)), kd_m));
                                 let case_name = "coerce".to_string();
                                 for (existing, status) in sub.sys.goals_mut().iter_mut() {
                                     if existing == &g && !status.solved {
@@ -7587,10 +7583,7 @@ impl<'ctx> Reduction<'ctx> {
                     );
                     let res = sub.insert_edge_labeled(
                         "chain_direct",
-                        crate::constraint::constraints::Edge {
-                            src: *c,
-                            tgt: *p,
-                        },
+                        crate::constraint::constraints::Edge { src: *c, tgt: *p },
                     );
                     if !matches!(res, Err(_) | Ok(SolveOutcome::Contradictory)) {
                         // Direct-edge chain: name by the chain conc's KD
@@ -7751,10 +7744,7 @@ impl<'ctx> Reduction<'ctx> {
                         (new_node, crate::rule::PremIdx(0)),
                         prem0.clone(),
                     ));
-                    arm_sub.insert_goal(Goal::Chain(
-                        (new_node, crate::rule::ConcIdx(0)),
-                        *p,
-                    ));
+                    arm_sub.insert_goal(Goal::Chain((new_node, crate::rule::ConcIdx(0)), *p));
                     let arm_counter = arm_sub.maude.fresh_counter_peek();
                     arm_sys = arm_sub.sys;
                     for (existing, status) in arm_sys.goals_mut().iter_mut() {
@@ -8029,10 +8019,7 @@ impl<'ctx> Reduction<'ctx> {
                         prem0.clone(),
                     ));
                     // Insert the chain continuation (i, ConcIdx(0)) → p.
-                    arm_sub.insert_goal(Goal::Chain(
-                        (new_node, crate::rule::ConcIdx(0)),
-                        *p,
-                    ));
+                    arm_sub.insert_goal(Goal::Chain((new_node, crate::rule::ConcIdx(0)), *p));
                     let arm_counter = arm_sub.maude.fresh_counter_peek();
                     arm_sys = arm_sub.sys;
                     // Mark the original chain goal as solved in this case
@@ -8191,8 +8178,7 @@ impl<'ctx> Reduction<'ctx> {
                         sub.maude.ensure_above(avoid_max);
                         let new_var = LVar::new("newVar", LSort::Nat, sub.maude.fresh_idx());
                         // sPlus = s ++: varTerm newVar
-                        let s_plus =
-                            f_app_ac(AcSym::NatPlus, vec![s.clone(), var_term(new_var)]);
+                        let s_plus = f_app_ac(AcSym::NatPlus, vec![s.clone(), var_term(new_var)]);
                         // insertFormula $ closeGuarded Ex [newVar] [EqE sPlus t] gtrue
                         let f = close_guarded_ex_eq(&new_var, &s_plus, t);
                         sub.insert_formula(f);

--- a/crates/tamarin-theory/src/constraint/solver/rename_precise.rs
+++ b/crates/tamarin-theory/src/constraint/solver/rename_precise.rs
@@ -93,7 +93,7 @@ pub fn rename_precise_system(sys: &mut System) {
         crate::constraint::constraints::NodeId,
         crate::rule::RuleACInst,
     )> = sys.nodes.iter().collect();
-    nodes_sorted.sort_by(|a, b| a.0.cmp(&b.0));
+    nodes_sorted.sort_by_key(|a| a.0);
     for (id, rule) in nodes_sorted {
         state.import(id);
         rule.for_each_free(&mut |v| {
@@ -280,7 +280,7 @@ pub fn rename_precise_system(sys: &mut System) {
 
     let term_subst: Subst<tamarin_term::lterm::Name, LVar> = Subst::from_list(
         map.iter()
-            .map(|(old, new)| (old.0.clone(), Term::Lit(Lit::Var(new.clone())))),
+            .map(|(old, new)| (old.0, Term::Lit(Lit::Var(*new)))),
     );
     // Hashed leaf-lookup view over the pass-invariant rename subst
     // (`SubstView`): Phase 2 applies this ONE fixed var→var substitution to
@@ -342,7 +342,7 @@ pub fn rename_precise_system(sys: &mut System) {
             let mut nodes = std::sync::Arc::unwrap_or_clone(std::mem::take(
                 &mut sys.content_mut_untracked().nodes,
             ));
-            nodes.sort_by(|a, b| a.0.cmp(&b.0));
+            nodes.sort_by_key(|a| a.0);
             sys.content_mut_untracked().nodes = std::sync::Arc::new(nodes);
         }
     } else {
@@ -363,14 +363,14 @@ pub fn rename_precise_system(sys: &mut System) {
                 (new_id, new_rule)
             })
             .collect();
-        renamed.sort_by(|a, b| a.0.cmp(&b.0));
+        renamed.sort_by_key(|a| a.0);
         sys.content_mut_untracked().nodes = std::sync::Arc::new(renamed);
     }
 
     // 2. Edges.
     for e in sys.content_mut_untracked().edges.iter_mut() {
-        e.src.0 = map_var(e.src.0.clone());
-        e.tgt.0 = map_var(e.tgt.0.clone());
+        e.src.0 = map_var(e.src.0);
+        e.tgt.0 = map_var(e.tgt.0);
     }
     // Dedup after rename — sort + dedup (matches subst_system).
     let mut tmp: Vec<_> = std::mem::take(&mut sys.content_mut_untracked().edges);
@@ -396,8 +396,8 @@ pub fn rename_precise_system(sys: &mut System) {
         Vec::with_capacity(sys.less_atoms.len());
     for la in std::mem::take(&mut sys.content_mut_untracked().less_atoms) {
         let mut la = la;
-        la.smaller = map_var(la.smaller.clone());
-        la.larger = map_var(la.larger.clone());
+        la.smaller = map_var(la.smaller);
+        la.larger = map_var(la.larger);
         new_less.push(la);
     }
     // Sort + dedup (O(n log n)), matching HS's `S.fromList` over the renamed
@@ -684,7 +684,7 @@ impl RenameState {
         }
         // First occurrence only (rare): materialise the owned key.
         self.map.insert(
-            VarKey(v.clone()),
+            VarKey(*v),
             LVar {
                 name: v.name,
                 sort: v.sort,

--- a/crates/tamarin-theory/src/constraint/solver/rename_precise.rs
+++ b/crates/tamarin-theory/src/constraint/solver/rename_precise.rs
@@ -306,7 +306,7 @@ pub fn rename_precise_system(sys: &mut System) {
         })
         .collect();
 
-    let map_var = |v: LVar| -> LVar { map.get(&v).cloned().unwrap_or(v) };
+    let map_var = |v: LVar| -> LVar { map.get(&v).copied().unwrap_or(v) };
 
     // 1. Nodes — id + rule.
     //

--- a/crates/tamarin-theory/src/constraint/solver/simplify.rs
+++ b/crates/tamarin-theory/src/constraint/solver/simplify.rs
@@ -5847,7 +5847,7 @@ mod tests {
         sys.content_mut()
             .less_atoms
             .push(crate::constraint::constraints::LessAtom::new(
-                n.clone(),
+                n,
                 m,
                 crate::constraint::constraints::Reason::Formula,
             ));
@@ -6168,8 +6168,8 @@ mod tests {
         };
         let id_a = tamarin_term::lterm::LVar::new("a", tamarin_term::lterm::LSort::Node, 1);
         let id_b = tamarin_term::lterm::LVar::new("b", tamarin_term::lterm::LSort::Node, 2);
-        sys.add_node(id_a.clone(), mk_rule());
-        sys.add_node(id_b.clone(), mk_rule());
+        sys.add_node(id_a, mk_rule());
+        sys.add_node(id_b, mk_rule());
         let mut r = Reduction::new(&ctx, sys);
         let res = enforce_ku_action_uniqueness_pass(&mut r);
         assert_eq!(
@@ -6178,8 +6178,8 @@ mod tests {
             "should report Changed after merging two KU(m) producers"
         );
         // The eq-store should now equate `a` and `b`.
-        let id_term_a = tamarin_term::term::Term::Lit(tamarin_term::vterm::Lit::Var(id_a.clone()));
-        let id_term_b = tamarin_term::term::Term::Lit(tamarin_term::vterm::Lit::Var(id_b.clone()));
+        let id_term_a = tamarin_term::term::Term::Lit(tamarin_term::vterm::Lit::Var(id_a));
+        let id_term_b = tamarin_term::term::Term::Lit(tamarin_term::vterm::Lit::Var(id_b));
         let mapped_a = tamarin_term::subst::apply_vterm(&r.sys.eq_store.subst, id_term_a);
         let mapped_b = tamarin_term::subst::apply_vterm(&r.sys.eq_store.subst, id_term_b);
         assert_eq!(
@@ -6268,7 +6268,7 @@ mod tests {
         // Wire S as injective with one Constant behaviour position.
         let s_tag = crate::fact::FactTag::Proto(crate::fact::Multiplicity::Linear, "S", 2);
         ctx.injective_fact_insts = vec![(
-            s_tag.clone(),
+            s_tag,
             vec![vec![
                 crate::tools::injective_fact_instances::MonotonicBehaviour::Constant,
             ]],
@@ -6279,13 +6279,13 @@ mod tests {
             tamarin_term::term::Term::Lit(tamarin_term::vterm::Lit::Var(id));
         let k1 = tamarin_term::lterm::LVar::new("k", tamarin_term::lterm::LSort::Msg, 1);
         let k1_t: tamarin_term::lterm::LNTerm =
-            tamarin_term::term::Term::Lit(tamarin_term::vterm::Lit::Var(k1.clone()));
+            tamarin_term::term::Term::Lit(tamarin_term::vterm::Lit::Var(k1));
         let k2 = tamarin_term::lterm::LVar::new("k", tamarin_term::lterm::LSort::Msg, 2);
         let k2_t: tamarin_term::lterm::LNTerm =
-            tamarin_term::term::Term::Lit(tamarin_term::vterm::Lit::Var(k2.clone()));
+            tamarin_term::term::Term::Lit(tamarin_term::vterm::Lit::Var(k2));
 
-        let s_fact_a = crate::fact::Fact::new(s_tag.clone(), vec![id_t.clone(), k1_t.clone()]);
-        let s_fact_b = crate::fact::Fact::new(s_tag.clone(), vec![id_t.clone(), k2_t.clone()]);
+        let s_fact_a = crate::fact::Fact::new(s_tag, vec![id_t.clone(), k1_t.clone()]);
+        let s_fact_b = crate::fact::Fact::new(s_tag, vec![id_t.clone(), k2_t.clone()]);
 
         let info = || {
             crate::rule::RuleInfo::Proto(crate::rule::ProtoRuleACInstInfo {
@@ -6342,7 +6342,7 @@ mod tests {
         let mut ctx = ProofContext::new(h, Vec::new());
         use crate::tools::injective_fact_instances::MonotonicBehaviour::{Constant, Unstable};
         let s_tag = crate::fact::FactTag::Proto(crate::fact::Multiplicity::Linear, "S", 2);
-        ctx.injective_fact_insts = vec![(s_tag.clone(), vec![vec![Unstable, Constant]])];
+        ctx.injective_fact_insts = vec![(s_tag, vec![vec![Unstable, Constant]])];
 
         let mk_var = |n: &str, sort, idx| -> tamarin_term::lterm::LNTerm {
             tamarin_term::term::Term::Lit(tamarin_term::vterm::Lit::Var(
@@ -6361,11 +6361,11 @@ mod tests {
         let k2 = mk_var("k", tamarin_term::lterm::LSort::Msg, 2);
 
         let s_fact_a = crate::fact::Fact::new(
-            s_tag.clone(),
+            s_tag,
             vec![id_t.clone(), pair(a1.clone(), k1.clone())],
         );
         let s_fact_b = crate::fact::Fact::new(
-            s_tag.clone(),
+            s_tag,
             vec![id_t.clone(), pair(a2.clone(), k2.clone())],
         );
 
@@ -6440,11 +6440,11 @@ mod tests {
         let id_a = tamarin_term::lterm::LVar::new("a", tamarin_term::lterm::LSort::Node, 1);
         let id_b = tamarin_term::lterm::LVar::new("b", tamarin_term::lterm::LSort::Node, 2);
         sys.add_node(
-            id_a.clone(),
+            id_a,
             crate::rule::Rule::new(info(), vec![], vec![], vec![mk_ku("k1", 0)]),
         );
         sys.add_node(
-            id_b.clone(),
+            id_b,
             crate::rule::Rule::new(info(), vec![], vec![], vec![mk_ku("k2", 0)]),
         );
         let mut r = Reduction::new(&ctx, sys);

--- a/crates/tamarin-theory/src/constraint/solver/simplify.rs
+++ b/crates/tamarin-theory/src/constraint/solver/simplify.rs
@@ -658,11 +658,7 @@ fn exploit_unique_msg_order(red: &mut Reduction) {
     for (m, i_kd) in &kd_conc {
         if let Some(i_ku) = ku_act.get(m) {
             if i_kd != i_ku {
-                red.insert_less(LessAtom::new(
-                    *i_kd,
-                    *i_ku,
-                    Reason::NormalForm,
-                ));
+                red.insert_less(LessAtom::new(*i_kd, *i_ku, Reason::NormalForm));
             }
         }
     }
@@ -2635,10 +2631,7 @@ fn enforce_fresh_node_uniqueness_pass(red: &mut Reduction) -> ChangeIndicator {
         let eqs: Vec<_> = ids
             .into_iter()
             .skip(1)
-            .map(|i| tamarin_term::rewriting::Equal {
-                lhs: keep,
-                rhs: i,
-            })
+            .map(|i| tamarin_term::rewriting::Equal { lhs: keep, rhs: i })
             .collect();
         // Haskell `enforceNodeUniqueness` freshRuleInsts branch
         // (Simplify.hs) calls `solveNodeIdEqs` via the `merge`
@@ -3448,12 +3441,7 @@ fn enforce_fresh_ordering_pass(red: &mut Reduction) -> ChangeIndicator {
     let edge_map: std::collections::BTreeMap<
         crate::constraint::constraints::NodeConc,
         crate::constraint::constraints::NodeId,
-    > = red
-        .sys
-        .edges
-        .iter()
-        .map(|e| (e.src, e.tgt.0))
-        .collect();
+    > = red.sys.edges.iter().map(|e| (e.src, e.tgt.0)).collect();
     fn plain_route(
         nid: &crate::constraint::constraints::NodeId,
         single_linear_conc: &std::collections::BTreeSet<crate::constraint::constraints::NodeId>,
@@ -3615,8 +3603,7 @@ fn enforce_fresh_ordering_pass(red: &mut Reduction) -> ChangeIndicator {
     // this step, Rust falsifies a verified lemma — confirmed against
     // Haskell `interactive`'s dot output (LessAtom `#i < #j Fresh`
     // comes from `enhancedLesses`).
-    let supplier_ids: std::collections::BTreeSet<_> =
-        suppliers.iter().map(|(id, _)| *id).collect();
+    let supplier_ids: std::collections::BTreeSet<_> = suppliers.iter().map(|(id, _)| *id).collect();
     for (i, j) in &new_lesses {
         if !supplier_ids.contains(i) {
             continue;
@@ -5325,11 +5312,8 @@ fn nat_subterm_equalities(
     }
 
     // `vertexToInt v = lookup v $ zip vertices [0..]` (SubtermStore.hs:395-538, see line 440)
-    let vertex_to_int: std::collections::BTreeMap<Vertex, usize> = vertices
-        .iter()
-        .enumerate()
-        .map(|(i, v)| (*v, i))
-        .collect();
+    let vertex_to_int: std::collections::BTreeMap<Vertex, usize> =
+        vertices.iter().enumerate().map(|(i, v)| (*v, i)).collect();
     let vti = |v: &Vertex| -> usize { vertex_to_int[v] };
 
     // `oneEdges = map ... $ filter fst vertices` (SubtermStore.hs:395-538, see line 443) —

--- a/crates/tamarin-theory/src/constraint/solver/simplify.rs
+++ b/crates/tamarin-theory/src/constraint/solver/simplify.rs
@@ -5247,12 +5247,12 @@ fn nat_subterm_equalities(
         let l_vars: Vec<LVar> = l_flat
             .iter()
             .filter(|t| *t != &one)
-            .filter_map(|t| get_var(t).cloned())
+            .filter_map(|t| get_var(t).copied())
             .collect();
         let r_vars: Vec<LVar> = r_flat
             .iter()
             .filter(|t| *t != &one)
-            .filter_map(|t| get_var(t).cloned())
+            .filter_map(|t| get_var(t).copied())
             .collect();
         let l_ones = l_flat.iter().filter(|t| *t == &one).count() as i64;
         let r_ones = r_flat.iter().filter(|t| *t == &one).count() as i64;
@@ -5328,8 +5328,8 @@ fn nat_subterm_equalities(
 
     // `rawEdges = realEdges ++ oneEdges` (SubtermStore.hs:395-538, see line 446)
     let mut raw_edges: Vec<((Vertex, Vertex), i64)> = Vec::new();
-    raw_edges.extend(real_edges.iter().cloned());
-    raw_edges.extend(one_edges.iter().cloned());
+    raw_edges.extend(real_edges.iter().copied());
+    raw_edges.extend(one_edges.iter().copied());
 
     // `inf = maxBound `div` 2` — large sentinel, avoid overflow in `ik + kj`.
     let inf: i64 = i64::MAX / 4;
@@ -5588,7 +5588,7 @@ fn nat_subterm_equalities(
             }
         }
         // `filter fst scc` — keep only True-tagged vertices.
-        let positives: Vec<Vertex> = scc.iter().filter(|v| v.0).cloned().collect();
+        let positives: Vec<Vertex> = scc.iter().filter(|v| v.0).copied().collect();
         // `delete smallest positives` — remove if present.
         let mut ys: Vec<Vertex> = Vec::new();
         let mut removed = false;

--- a/crates/tamarin-theory/src/constraint/solver/simplify.rs
+++ b/crates/tamarin-theory/src/constraint/solver/simplify.rs
@@ -534,14 +534,14 @@ fn non_injective_fact_instances_pairs(
         crate::constraint::constraints::NodeId,
         crate::rule::RuleACInst,
     )> = sys.nodes.iter().collect();
-    nodes_sorted.sort_by(|a, b| a.0.cmp(&b.0));
+    nodes_sorted.sort_by_key(|a| a.0);
     // The `alwaysBefore` adjacency is invariant across the edge/node loop
     // (`sys` is read-only), so build it once and query with
     // `always_before_with` instead of rebuilding the relation per pair.
     let ab_adj = sys.build_always_before_adj();
     for e in &edges_sorted {
-        let (i, conc_idx) = (e.src.0.clone(), e.src.1);
-        let k = e.tgt.0.clone();
+        let (i, conc_idx) = (e.src.0, e.src.1);
+        let k = e.tgt.0;
         let i_rule = match lookup_node(&i) {
             Some(r) => r,
             None => continue,
@@ -576,14 +576,14 @@ fn non_injective_fact_instances_pairs(
             }
             // checkRuleJK: j<k and nonUnifiable(j, i) — return (j, i)
             if non_unifiable_nodes(j, &i) {
-                out.push((j.clone(), i.clone()));
+                out.push((*j, i));
                 continue;
             }
             // checkRuleIJ: i<j and nonUnifiable(k, j) — return (k, j)
             // Haskell's IJ branch uses `D.reachableSet [i] less`; we
             // mirror that with `i < j`.
             if sys.always_before_with(&ab_adj, &i, j) && non_unifiable_nodes(&k, j) {
-                out.push((k.clone(), j.clone()));
+                out.push((k, *j));
             }
         }
     }
@@ -615,7 +615,7 @@ fn exploit_unique_msg_order(red: &mut Reduction) {
                 if let Some(m) = fa.terms.first() {
                     // First occurrence wins; N5↓ has already merged
                     // duplicates by this point.
-                    kd_conc.entry(m.clone()).or_insert_with(|| id.clone());
+                    kd_conc.entry(m.clone()).or_insert_with(|| *id);
                 }
             }
         }
@@ -634,7 +634,7 @@ fn exploit_unique_msg_order(red: &mut Reduction) {
         for fa in &rule.actions {
             if matches!(fa.tag, FactTag::Ku) {
                 if let Some(m) = fa.terms.first() {
-                    ku_act.entry(m.clone()).or_insert_with(|| id.clone());
+                    ku_act.entry(m.clone()).or_insert_with(|| *id);
                 }
             }
         }
@@ -646,7 +646,7 @@ fn exploit_unique_msg_order(red: &mut Reduction) {
         if let crate::constraint::constraints::Goal::Action(i, fa) = goal {
             if matches!(fa.tag, FactTag::Ku) {
                 if let Some(m) = fa.terms.first() {
-                    ku_act.entry(m.clone()).or_insert_with(|| i.clone());
+                    ku_act.entry(m.clone()).or_insert_with(|| *i);
                 }
             }
         }
@@ -659,8 +659,8 @@ fn exploit_unique_msg_order(red: &mut Reduction) {
         if let Some(i_ku) = ku_act.get(m) {
             if i_kd != i_ku {
                 red.insert_less(LessAtom::new(
-                    i_kd.clone(),
-                    i_ku.clone(),
+                    *i_kd,
+                    *i_ku,
                     Reason::NormalForm,
                 ));
             }
@@ -1052,17 +1052,17 @@ fn partial_atom_valuation_with(
             )> = sys
                 .less_atoms
                 .iter()
-                .map(|l| (l.smaller.clone(), l.larger.clone()))
-                .chain(sys.edges.iter().map(|e| (e.src.0.clone(), e.tgt.0.clone())))
+                .map(|l| (l.smaller, l.larger))
+                .chain(sys.edges.iter().map(|e| (e.src.0, e.tgt.0)))
                 .collect();
             // nodesAfter n = transitive closure from n via less_rel.
-            let mut frontier: Vec<crate::constraint::constraints::NodeId> = vec![n.clone()];
-            let mut seen: std::collections::BTreeSet<_> = [n.clone()].into_iter().collect();
+            let mut frontier: Vec<crate::constraint::constraints::NodeId> = vec![n];
+            let mut seen: std::collections::BTreeSet<_> = [n].into_iter().collect();
             while let Some(cur) = frontier.pop() {
                 for (a, b) in &less_rel {
                     if a == &cur && !seen.contains(b) {
-                        seen.insert(b.clone());
-                        frontier.push(b.clone());
+                        seen.insert(*b);
+                        frontier.push(*b);
                     }
                 }
             }
@@ -1300,7 +1300,7 @@ fn insert_implied_formulas_pass(red: &mut Reduction) -> ChangeIndicator {
             .iter()
             .filter(|(_, st)| !st.solved)
             .filter_map(|(g, _)| match g {
-                Goal::Action(i, fa) => Some((i.clone(), fa.clone())),
+                Goal::Action(i, fa) => Some((*i, fa.clone())),
                 _ => None,
             })
             .collect();
@@ -1309,10 +1309,10 @@ fn insert_implied_formulas_pass(red: &mut Reduction) -> ChangeIndicator {
         Vec::new();
     for (id, rule) in red.sys.nodes.iter() {
         for a in &rule.actions {
-            node_actions.push((id.clone(), a.clone()));
+            node_actions.push((*id, a.clone()));
         }
     }
-    node_actions.sort_by(|a, b| a.0.cmp(&b.0));
+    node_actions.sort_by_key(|a| a.0);
     let mut sys_actions = unsolved_actions;
     sys_actions.extend(node_actions);
     if sys_actions.is_empty() {
@@ -2248,7 +2248,7 @@ fn structural_match(
             if matches!(subj, Term::Lit(Lit::Var(sv)) if sv == pv) {
                 return StructMatch::Matched;
             }
-            subst.insert(pv.clone(), subj.clone());
+            subst.insert(*pv, subj.clone());
             StructMatch::Matched
         }
         // Non-pattern LVar = SkConst-equivalent: matches only the same
@@ -2526,12 +2526,12 @@ fn normalise_less_atoms_pass(red: &mut Reduction) -> ChangeIndicator {
         let subst = &c.eq_store.subst;
         let normalize = |id: &crate::constraint::constraints::NodeId| -> crate::constraint::constraints::NodeId {
             let t = tamarin_term::term::Term::Lit(
-                tamarin_term::vterm::Lit::Var(id.clone()));
+                tamarin_term::vterm::Lit::Var(*id));
             let mapped = tamarin_term::subst::apply_vterm(subst, t);
             if let tamarin_term::term::Term::Lit(tamarin_term::vterm::Lit::Var(v)) = mapped {
                 v
             } else {
-                id.clone()
+                *id
             }
         };
         for la in c.less_atoms.iter_mut() {
@@ -2567,7 +2567,7 @@ fn normalise_less_atoms_pass(red: &mut Reduction) -> ChangeIndicator {
     let mut seen: tamarin_utils::FastSet<(tamarin_term::lterm::LVar, tamarin_term::lterm::LVar)> =
         tamarin_utils::FastSet::default();
     for la in std::mem::take(&mut red.sys.content_mut_untracked().less_atoms) {
-        if seen.insert((la.smaller.clone(), la.larger.clone())) {
+        if seen.insert((la.smaller, la.larger)) {
             new_less.push(la);
         }
     }
@@ -2607,9 +2607,9 @@ fn enforce_fresh_node_uniqueness_pass(red: &mut Reduction) -> ChangeIndicator {
             continue;
         }
         if let Some(slot) = buckets.iter_mut().find(|(r, _)| r == rule) {
-            slot.1.push(id.clone());
+            slot.1.push(*id);
         } else {
-            buckets.push((rule.clone(), vec![id.clone()]));
+            buckets.push((rule.clone(), vec![*id]));
         }
     }
     let mut changed = ChangeIndicator::Unchanged;
@@ -2631,12 +2631,12 @@ fn enforce_fresh_node_uniqueness_pass(red: &mut Reduction) -> ChangeIndicator {
         // order is immaterial; only the in-group keep-direction matters.)
         let mut ids = ids;
         ids.sort();
-        let keep = ids[0].clone();
+        let keep = ids[0];
         let eqs: Vec<_> = ids
             .into_iter()
             .skip(1)
             .map(|i| tamarin_term::rewriting::Equal {
-                lhs: keep.clone(),
+                lhs: keep,
                 rhs: i,
             })
             .collect();
@@ -2720,7 +2720,7 @@ fn enforce_ku_action_uniqueness_pass(red: &mut Reduction) -> ChangeIndicator {
         if let Goal::Action(i, fa) = g {
             if matches!(fa.tag, FactTag::Ku) {
                 if let Some(m) = fa.terms.first() {
-                    acts.push((i.clone(), fa.clone(), apply_subst(m)));
+                    acts.push((*i, fa.clone(), apply_subst(m)));
                 }
             }
         }
@@ -2736,12 +2736,12 @@ fn enforce_ku_action_uniqueness_pass(red: &mut Reduction) -> ChangeIndicator {
     // still pushed FIRST — `allKUActions` lists `unsolvedActionAtoms`
     // before rule actions — so a goal still wins `iKeep` over a rule node.)
     let mut sorted_nodes: Vec<_> = red.sys.nodes.iter().collect();
-    sorted_nodes.sort_by(|a, b| a.0.cmp(&b.0));
+    sorted_nodes.sort_by_key(|a| a.0);
     for (id, rule) in sorted_nodes {
         for fa in &rule.actions {
             if matches!(fa.tag, FactTag::Ku) {
                 if let Some(m) = fa.terms.first() {
-                    acts.push((id.clone(), fa.clone(), apply_subst(m)));
+                    acts.push((*id, fa.clone(), apply_subst(m)));
                 }
             }
         }
@@ -2765,8 +2765,8 @@ fn enforce_ku_action_uniqueness_pass(red: &mut Reduction) -> ChangeIndicator {
         for (rid, rfa) in group.iter().skip(1) {
             if rid != keep_id {
                 node_eqs.push(tamarin_term::rewriting::Equal {
-                    lhs: keep_id.clone(),
-                    rhs: rid.clone(),
+                    lhs: *keep_id,
+                    rhs: *rid,
                 });
             }
             if rfa != keep_fa {
@@ -3171,12 +3171,12 @@ fn collect_unique_action_candidates(
         std::collections::BTreeMap::new();
     for r in &red.ctx.rules {
         for fa in &r.rule.actions {
-            *counts.entry((fa.tag.clone(), fa.terms.len())).or_insert(0) += 1;
+            *counts.entry((fa.tag, fa.terms.len())).or_insert(0) += 1;
         }
     }
     for r in &red.ctx.intruder_rules {
         for fa in &r.actions {
-            *counts.entry((fa.tag.clone(), fa.terms.len())).or_insert(0) += 1;
+            *counts.entry((fa.tag, fa.terms.len())).or_insert(0) += 1;
         }
     }
     let is_unique = |fa: &LNFact| -> bool {
@@ -3187,7 +3187,7 @@ fn collect_unique_action_candidates(
                 return false;
             }
         }
-        counts.get(&(fa.tag.clone(), fa.terms.len())).copied() == Some(1)
+        counts.get(&(fa.tag, fa.terms.len())).copied() == Some(1)
     };
 
     let mut candidates: Vec<(crate::constraint::constraints::NodeId, LNFact)> = red
@@ -3195,7 +3195,7 @@ fn collect_unique_action_candidates(
         .goals
         .iter()
         .filter_map(|(g, st)| match g {
-            Goal::Action(i, fa) if !st.solved && is_unique(fa) => Some((i.clone(), fa.clone())),
+            Goal::Action(i, fa) if !st.solved && is_unique(fa) => Some((*i, fa.clone())),
             _ => None,
         })
         .collect();
@@ -3258,7 +3258,7 @@ fn enforce_kd_fact_uniqueness_pass(red: &mut Reduction) -> ChangeIndicator {
         for fa in &rule.conclusions {
             if matches!(fa.tag, FactTag::Kd) {
                 if let Some(m) = fa.terms.first() {
-                    kd_concs.push((id.clone(), rule.clone(), m.clone()));
+                    kd_concs.push((*id, rule.clone(), m.clone()));
                 }
             }
         }
@@ -3281,8 +3281,8 @@ fn enforce_kd_fact_uniqueness_pass(red: &mut Reduction) -> ChangeIndicator {
         for (rid, rrule) in group.iter().skip(1) {
             if rid != keep_id {
                 node_eqs.push(tamarin_term::rewriting::Equal {
-                    lhs: keep_id.clone(),
-                    rhs: rid.clone(),
+                    lhs: *keep_id,
+                    rhs: *rid,
                 });
             }
             if keep_rule != rrule {
@@ -3376,7 +3376,7 @@ fn enforce_fresh_ordering_pass(red: &mut Reduction) -> ChangeIndicator {
                 };
                 if let Term::Lit(Lit::Var(v)) = t_norm {
                     if v.sort == tamarin_term::lterm::LSort::Fresh {
-                        suppliers.push((id.clone(), v));
+                        suppliers.push((*id, v));
                     }
                 }
             }
@@ -3439,7 +3439,7 @@ fn enforce_fresh_ordering_pass(red: &mut Reduction) -> ChangeIndicator {
         nodes_snapshot
             .iter()
             .filter(|(_, r)| r.conclusions.len() == 1 && r.conclusions[0].is_linear())
-            .map(|(id, _)| id.clone())
+            .map(|(id, _)| *id)
             .collect();
     // edge_map: NodeConc → NodeId (only first edge per conc is needed since the
     // source case has at most one outgoing edge per conc).  Built directly from
@@ -3452,7 +3452,7 @@ fn enforce_fresh_ordering_pass(red: &mut Reduction) -> ChangeIndicator {
         .sys
         .edges
         .iter()
-        .map(|e| (e.src.clone(), e.tgt.0.clone()))
+        .map(|e| (e.src, e.tgt.0))
         .collect();
     fn plain_route(
         nid: &crate::constraint::constraints::NodeId,
@@ -3469,16 +3469,16 @@ fn enforce_fresh_ordering_pass(red: &mut Reduction) -> ChangeIndicator {
         // iff it has a single linear conclusion (precomputed) — i.e. `nid`'s
         // rule has exactly one, linear conclusion.
         if depth > 32 || !single_linear_conc.contains(nid) {
-            return vec![nid.clone()];
+            return vec![*nid];
         }
-        let conc_key = (nid.clone(), crate::rule::ConcIdx(0));
+        let conc_key = (*nid, crate::rule::ConcIdx(0));
         match edge_map.get(&conc_key) {
             Some(next) => {
-                let mut out = vec![nid.clone()];
+                let mut out = vec![*nid];
                 out.extend(plain_route(next, single_linear_conc, edge_map, depth + 1));
                 out
             }
-            None => vec![nid.clone()],
+            None => vec![*nid],
         }
     }
 
@@ -3583,13 +3583,13 @@ fn enforce_fresh_ordering_pass(red: &mut Reduction) -> ChangeIndicator {
                 less_idx = Some(red.sys.build_less_index());
             }
             if red.sys.add_less_indexed(
-                LessAtom::new(sup_id.clone(), other_id.clone(), Reason::Fresh),
+                LessAtom::new(*sup_id, *other_id, Reason::Fresh),
                 less_idx.as_mut().unwrap(),
             ) {
                 red.changed = ChangeIndicator::Changed;
                 changed = ChangeIndicator::Changed;
             }
-            new_lesses.push((sup_id.clone(), other_id.clone()));
+            new_lesses.push((*sup_id, *other_id));
         }
     }
 
@@ -3616,7 +3616,7 @@ fn enforce_fresh_ordering_pass(red: &mut Reduction) -> ChangeIndicator {
     // Haskell `interactive`'s dot output (LessAtom `#i < #j Fresh`
     // comes from `enhancedLesses`).
     let supplier_ids: std::collections::BTreeSet<_> =
-        suppliers.iter().map(|(id, _)| id.clone()).collect();
+        suppliers.iter().map(|(id, _)| *id).collect();
     for (i, j) in &new_lesses {
         if !supplier_ids.contains(i) {
             continue;
@@ -3648,7 +3648,7 @@ fn enforce_fresh_ordering_pass(red: &mut Reduction) -> ChangeIndicator {
             continue;
         }
         let last = match rs.last() {
-            Some(l) => l.clone(),
+            Some(l) => *l,
             None => continue,
         };
         // HS-faithful insertLess (Reduction.hs:390-391).  `less_idx` stays
@@ -3658,7 +3658,7 @@ fn enforce_fresh_ordering_pass(red: &mut Reduction) -> ChangeIndicator {
             less_idx = Some(red.sys.build_less_index());
         }
         if red.sys.add_less_indexed(
-            LessAtom::new(last, j.clone(), Reason::Fresh),
+            LessAtom::new(last, *j, Reason::Fresh),
             less_idx.as_mut().unwrap(),
         ) {
             red.changed = ChangeIndicator::Changed;
@@ -3729,7 +3729,7 @@ fn enforce_edge_uniqueness_pass(red: &mut Reduction) -> ChangeIndicator {
                     | FactTag::Ku
                     | FactTag::Kd
             ) {
-                persistent_concs.insert((id.clone(), i));
+                persistent_concs.insert((*id, i));
             }
         }
     }
@@ -3746,8 +3746,8 @@ fn enforce_edge_uniqueness_pass(red: &mut Reduction) -> ChangeIndicator {
         Vec<crate::constraint::constraints::NodePrem>,
     > = std::collections::BTreeMap::new();
     for e in &red.sys.edges {
-        by_tgt.entry(e.tgt.clone()).or_default().push(e.src.clone());
-        by_src.entry(e.src.clone()).or_default().push(e.tgt.clone());
+        by_tgt.entry(e.tgt).or_default().push(e.src);
+        by_src.entry(e.src).or_default().push(e.tgt);
     }
     let mut node_eqs: Vec<tamarin_term::rewriting::Equal<crate::constraint::constraints::NodeId>> =
         Vec::new();
@@ -3764,8 +3764,8 @@ fn enforce_edge_uniqueness_pass(red: &mut Reduction) -> ChangeIndicator {
                 continue;
             }
             node_eqs.push(tamarin_term::rewriting::Equal {
-                lhs: keep.0.clone(),
-                rhs: other.0.clone(),
+                lhs: keep.0,
+                rhs: other.0,
             });
         }
     }
@@ -3780,7 +3780,7 @@ fn enforce_edge_uniqueness_pass(red: &mut Reduction) -> ChangeIndicator {
         if prems.len() < 2 {
             continue;
         }
-        if persistent_concs.contains(&(src.0.clone(), src.1 .0)) {
+        if persistent_concs.contains(&(src.0, src.1 .0)) {
             continue;
         }
         let keep = &prems[0];
@@ -3790,8 +3790,8 @@ fn enforce_edge_uniqueness_pass(red: &mut Reduction) -> ChangeIndicator {
                 continue;
             }
             node_eqs.push(tamarin_term::rewriting::Equal {
-                lhs: keep.0.clone(),
-                rhs: other.0.clone(),
+                lhs: keep.0,
+                rhs: other.0,
             });
         }
     }
@@ -3835,7 +3835,7 @@ fn enforce_edge_uniqueness_pass(red: &mut Reduction) -> ChangeIndicator {
 /// Lift a `NodeId` (an `LVar` of sort Node) to an `LNTerm` variable —
 /// HS `varTerm (Free i)` for a node-id.
 fn node_id_to_lnterm(n: &crate::constraint::constraints::NodeId) -> tamarin_term::lterm::LNTerm {
-    tamarin_term::term::Term::Lit(tamarin_term::vterm::Lit::Var(n.clone()))
+    tamarin_term::term::Term::Lit(tamarin_term::vterm::Lit::Var(*n))
 }
 
 /// `simpInjectiveFactEqMon` — direct port of Haskell's
@@ -3890,7 +3890,7 @@ fn simp_injective_fact_eq_mon_pass(red: &mut Reduction) -> ChangeIndicator {
         crate::constraint::constraints::NodeId,
         crate::rule::RuleACInst,
     )> = red.sys.nodes.iter().collect();
-    sorted_nodes.sort_by(|a, b| a.0.cmp(&b.0));
+    sorted_nodes.sort_by_key(|a| a.0);
     for (id, rule) in sorted_nodes {
         for prem in &rule.premises {
             if let Some((_, behaviours)) = red
@@ -3902,7 +3902,7 @@ fn simp_injective_fact_eq_mon_pass(red: &mut Reduction) -> ChangeIndicator {
                 if let Some((first, pairs)) =
                     crate::tools::injective_fact_instances::trimmed_pair_terms(prem, behaviours)
                 {
-                    by_inj.push((id.clone(), prem.tag.clone(), first, pairs));
+                    by_inj.push((*id, prem.tag, first, pairs));
                 }
             }
         }
@@ -4227,7 +4227,7 @@ fn simp_injective_fact_eq_mon_pass(red: &mut Reduction) -> ChangeIndicator {
                         // case (3) (Simplify.hs): [(i,j) |
                         //   triviallySmaller s t, not alwaysBefore i j]
                         if trivially_smaller(s, t) && !ab_ij {
-                            new_lesses.push((ii.clone(), jj.clone()));
+                            new_lesses.push((*ii, *jj));
                         }
                         // case (5) (Simplify.hs): [(j,i) |
                         //   triviallyNotSmaller s t, not alwaysBefore j i, ineq s t]
@@ -4236,7 +4236,7 @@ fn simp_injective_fact_eq_mon_pass(red: &mut Reduction) -> ChangeIndicator {
                             && (inequalities.contains(&(s.clone(), t.clone()))
                                 || inequalities.contains(&(t.clone(), s.clone())))
                         {
-                            new_lesses.push((jj.clone(), ii.clone()));
+                            new_lesses.push((*jj, *ii));
                         }
                     }
                     // HS-faithful Increasing (Simplify.hs):
@@ -4246,14 +4246,14 @@ fn simp_injective_fact_eq_mon_pass(red: &mut Reduction) -> ChangeIndicator {
                     //   again NOT gated on `s == t`.
                     MonotonicBehaviour::Increasing => {
                         if trivially_smaller(s, t) && !red.sys.always_before_with(&ab_adj, ii, jj) {
-                            new_lesses.push((ii.clone(), jj.clone()));
+                            new_lesses.push((*ii, *jj));
                         }
                         if trivially_not_smaller(s, t)
                             && !red.sys.always_before_with(&ab_adj, jj, ii)
                             && (inequalities.contains(&(s.clone(), t.clone()))
                                 || inequalities.contains(&(t.clone(), s.clone())))
                         {
-                            new_lesses.push((jj.clone(), ii.clone()));
+                            new_lesses.push((*jj, *ii));
                         }
                     }
                     _ => {}
@@ -4619,7 +4619,7 @@ fn propagate_subterm_obvious(red: &mut Reduction) -> ChangeIndicator {
                     Err(_) => None,
                     Ok((n_small, n_big)) => {
                         let new_var = mk_fresh(sort_of_lnterm(big));
-                        let small_plus = f_app_ac(f, vec![n_small, var_term(new_var.clone())]);
+                        let small_plus = f_app_ac(f, vec![n_small, var_term(new_var)]);
                         let mut out: Vec<Split> = Vec::new();
                         out.push(Split::AcNewVar(small_plus, n_big, new_var));
                         // map (curry SubtermD small) (flattenedACTerms f big)
@@ -4731,7 +4731,7 @@ fn propagate_subterm_obvious(red: &mut Reduction) -> ChangeIndicator {
                        new_var: &tamarin_term::lterm::LVar,
                        new_formulas: &mut Vec<crate::guarded::Guarded>| {
         let var_lt: tamarin_term::lterm::LNTerm =
-            tamarin_term::term::Term::Lit(tamarin_term::vterm::Lit::Var(new_var.clone()));
+            tamarin_term::term::Term::Lit(tamarin_term::vterm::Lit::Var(*new_var));
         let vs = match crate::elaborate::lnterm_to_term(&var_lt) {
             tamarin_parser::ast::Term::Var(v) => v,
             _ => return,
@@ -5274,25 +5274,25 @@ fn nat_subterm_equalities(
             let d: i64 = 2 * (r_ones - l_ones - 1);
             // `from = head $ map (True,) (getVars l) ++ map (False,) (getVars r)`
             let from: Vertex = if let Some(v) = l_vars.first() {
-                (true, v.clone())
+                (true, *v)
             } else {
                 // Must exist because total_vars == 1
-                (false, r_vars[0].clone())
+                (false, r_vars[0])
             };
-            let to: Vertex = (!from.0, from.1.clone());
+            let to: Vertex = (!from.0, from.1);
             vec![((from, to), d)]
         } else if total_vars == 2 {
             let d: i64 = r_ones - l_ones - 1;
             // `froms = map (True,) (getVars l) ++ map (False,) (getVars r)`
             let mut froms: Vec<Vertex> = Vec::with_capacity(2);
             for v in &l_vars {
-                froms.push((true, v.clone()));
+                froms.push((true, *v));
             }
             for v in &r_vars {
-                froms.push((false, v.clone()));
+                froms.push((false, *v));
             }
             // `tos = map (first not) (reverse froms)`
-            let mut tos: Vec<Vertex> = froms.iter().rev().map(|(s, v)| (!s, v.clone())).collect();
+            let mut tos: Vec<Vertex> = froms.iter().rev().map(|(s, v)| (!s, *v)).collect();
             let mut out = Vec::with_capacity(2);
             for _ in 0..2 {
                 let f = froms.remove(0);
@@ -5315,8 +5315,8 @@ fn nat_subterm_equalities(
     // BTreeSet for deterministic ordering matching HS Set semantics.
     let mut vertex_set: std::collections::BTreeSet<Vertex> = std::collections::BTreeSet::new();
     for ((a, b), _) in &real_edges {
-        vertex_set.insert(a.clone());
-        vertex_set.insert(b.clone());
+        vertex_set.insert(*a);
+        vertex_set.insert(*b);
     }
     let vertices: Vec<Vertex> = vertex_set.into_iter().collect();
     let n = vertices.len();
@@ -5328,7 +5328,7 @@ fn nat_subterm_equalities(
     let vertex_to_int: std::collections::BTreeMap<Vertex, usize> = vertices
         .iter()
         .enumerate()
-        .map(|(i, v)| (v.clone(), i))
+        .map(|(i, v)| (*v, i))
         .collect();
     let vti = |v: &Vertex| -> usize { vertex_to_int[v] };
 
@@ -5338,7 +5338,7 @@ fn nat_subterm_equalities(
     let mut one_edges: Vec<((Vertex, Vertex), i64)> = Vec::new();
     for v in &vertices {
         if v.0 {
-            one_edges.push((((false, v.1.clone()), (true, v.1.clone())), -2));
+            one_edges.push((((false, v.1), (true, v.1)), -2));
         }
     }
 
@@ -5385,14 +5385,14 @@ fn nat_subterm_equalities(
         if !v.0 {
             continue;
         }
-        let nv: Vertex = (false, v.1.clone());
+        let nv: Vertex = (false, v.1);
         let d = fw[vti(v) * n + vti(&nv)];
         let reachable = d < inf / 2;
         let is_even = d.rem_euclid(2) == 0;
         if reachable && is_even {
             continue;
         }
-        tightened_edges.push(((v.clone(), nv), d - 1));
+        tightened_edges.push(((*v, nv), d - 1));
     }
 
     // `edges = rawEdges ++ tightenedEdges` (SubtermStore.hs:395-538, see line 479)
@@ -5439,7 +5439,7 @@ fn nat_subterm_equalities(
             }
             w + df == dt
         })
-        .map(|((from, to), _)| (from.clone(), to.clone()))
+        .map(|((from, to), _)| (*from, *to))
         .collect();
 
     // ---- SCC of slackEdges (SubtermStore.hs:512-520) -------------------
@@ -5543,7 +5543,7 @@ fn nat_subterm_equalities(
     //
     // `addN y n`: `varTerm y + n * fAppNatOne` (HS line 531).
     fn add_n(y: &LVar, n: i64) -> LNTerm {
-        let var_term: LNTerm = Term::Lit(tamarin_term::vterm::Lit::Var(y.clone()));
+        let var_term: LNTerm = Term::Lit(tamarin_term::vterm::Lit::Var(*y));
         if n == 0 {
             return var_term;
         }
@@ -5587,7 +5587,7 @@ fn nat_subterm_equalities(
     let mut scc_vertices: Vec<Vec<Vertex>> = sccs
         .iter()
         .map(|comp| {
-            let mut s: Vec<Vertex> = comp.iter().map(|i| vertices[*i].clone()).collect();
+            let mut s: Vec<Vertex> = comp.iter().map(|i| vertices[*i]).collect();
             s.sort();
             s
         })
@@ -5597,10 +5597,10 @@ fn nat_subterm_equalities(
     for scc in &scc_vertices {
         // `smallest = foldr1 (\x y -> if getValue x < getValue y then x else y)`
         // HS `foldr1` walks right-to-left and ties go to the rightmost.
-        let mut smallest: Vertex = scc[scc.len() - 1].clone();
+        let mut smallest: Vertex = scc[scc.len() - 1];
         for v in scc.iter().rev().skip(1) {
             if get_value(v) < get_value(&smallest) {
-                smallest = v.clone();
+                smallest = *v;
             }
         }
         // `filter fst scc` — keep only True-tagged vertices.
@@ -5621,7 +5621,7 @@ fn nat_subterm_equalities(
             let lhs_var = &smallest.1;
             let rhs_var = &y.1;
             let n = get_value(y) - get_value(&smallest);
-            let lhs: LNTerm = Term::Lit(tamarin_term::vterm::Lit::Var(lhs_var.clone()));
+            let lhs: LNTerm = Term::Lit(tamarin_term::vterm::Lit::Var(*lhs_var));
             let rhs: LNTerm = add_n(rhs_var, n);
             equalities.push((lhs, rhs));
         }
@@ -5633,17 +5633,17 @@ fn nat_subterm_equalities(
         // multiset; the variables that appear more than once are the
         // duplicates.  We mirror HS's `xs \\ S.toList (S.fromList xs)` —
         // i.e. take each var and remove one copy of its first occurrence.
-        let snds: Vec<LVar> = scc.iter().map(|v| v.1.clone()).collect();
+        let snds: Vec<LVar> = scc.iter().map(|v| v.1).collect();
         let mut seen: std::collections::BTreeSet<LVar> = std::collections::BTreeSet::new();
         let mut dups: Vec<LVar> = Vec::new();
         for v in &snds {
-            if !seen.insert(v.clone()) {
-                dups.push(v.clone());
+            if !seen.insert(*v) {
+                dups.push(*v);
             }
         }
         for v in &dups {
-            let neg_v: Vertex = (false, v.clone());
-            let pos_v: Vertex = (true, v.clone());
+            let neg_v: Vertex = (false, *v);
+            let pos_v: Vertex = (true, *v);
             let val = (get_value(&neg_v) - get_value(&pos_v)) / 2;
             if val <= 0 {
                 // HS `termN` precondition `n > 0`; if `val ≤ 0` the absolute
@@ -5653,7 +5653,7 @@ fn nat_subterm_equalities(
                 // is enforced by the `oneEdges`).  Defensive.
                 continue;
             }
-            let lhs: LNTerm = Term::Lit(tamarin_term::vterm::Lit::Var(v.clone()));
+            let lhs: LNTerm = Term::Lit(tamarin_term::vterm::Lit::Var(*v));
             let rhs: LNTerm = term_n(val);
             equalities.push((lhs, rhs));
         }

--- a/crates/tamarin-theory/src/constraint/solver/simplify.rs
+++ b/crates/tamarin-theory/src/constraint/solver/simplify.rs
@@ -6360,14 +6360,10 @@ mod tests {
         let k1 = mk_var("k", tamarin_term::lterm::LSort::Msg, 1);
         let k2 = mk_var("k", tamarin_term::lterm::LSort::Msg, 2);
 
-        let s_fact_a = crate::fact::Fact::new(
-            s_tag,
-            vec![id_t.clone(), pair(a1.clone(), k1.clone())],
-        );
-        let s_fact_b = crate::fact::Fact::new(
-            s_tag,
-            vec![id_t.clone(), pair(a2.clone(), k2.clone())],
-        );
+        let s_fact_a =
+            crate::fact::Fact::new(s_tag, vec![id_t.clone(), pair(a1.clone(), k1.clone())]);
+        let s_fact_b =
+            crate::fact::Fact::new(s_tag, vec![id_t.clone(), pair(a2.clone(), k2.clone())]);
 
         let info = || {
             crate::rule::RuleInfo::Proto(crate::rule::ProtoRuleACInstInfo {

--- a/crates/tamarin-theory/src/constraint/solver/sources.rs
+++ b/crates/tamarin-theory/src/constraint/solver/sources.rs
@@ -7338,10 +7338,7 @@ mod tests {
     fn precompute_sources_drops_multi_producer() {
         use crate::fact::{FactTag, Multiplicity};
         let tag = FactTag::Proto(Multiplicity::Linear, "Bar", 0);
-        let rules = vec![
-            make_rule("MakeBarA", tag),
-            make_rule("MakeBarB", tag),
-        ];
+        let rules = vec![make_rule("MakeBarA", tag), make_rule("MakeBarB", tag)];
         let ctx = match ctx_with_rules(rules) {
             Some(c) => c,
             None => return,
@@ -7487,10 +7484,7 @@ mod tests {
         use crate::fact::{FactTag, Multiplicity};
         let tag_a = FactTag::Proto(Multiplicity::Linear, "A", 0);
         let tag_b = FactTag::Proto(Multiplicity::Linear, "B", 0);
-        let rules = vec![
-            make_rule("MakeA", tag_a),
-            make_rule("MakeB", tag_b),
-        ];
+        let rules = vec![make_rule("MakeA", tag_a), make_rule("MakeB", tag_b)];
         let ctx = match ctx_with_rules(rules) {
             Some(c) => c,
             None => return,

--- a/crates/tamarin-theory/src/constraint/solver/sources.rs
+++ b/crates/tamarin-theory/src/constraint/solver/sources.rs
@@ -2461,8 +2461,7 @@ fn run_solve_all_safe_goals_disj_with_progress(
                 found
             };
             if has_fresh_var {
-                let live_goal_action =
-                    crate::constraint::constraints::Goal::Action(i, fa.clone());
+                let live_goal_action = crate::constraint::constraints::Goal::Action(i, fa.clone());
                 for (g, st) in sub.sys.goals_mut().iter_mut() {
                     if g == &live_goal_action {
                         st.solved = true;
@@ -3733,10 +3732,10 @@ fn freshen_system_some_inst(
                     bindings.entry(lv).or_insert_with(|| {
                         let new_idx = maude.reserve_idxs(1);
                         tamarin_term::lterm::LVar {
-                                name: lv.name,
-                                sort: lv.sort,
-                                idx: new_idx,
-                            }
+                            name: lv.name,
+                            sort: lv.sort,
+                            idx: new_idx,
+                        }
                     });
                 }
                 v.clone()
@@ -4599,8 +4598,7 @@ fn conjoin_refine_arm(
     if let Some(m) = red_maude {
         r.maude = m.clone();
     }
-    let live_goal =
-        crate::constraint::constraints::Goal::Action(*live_node, fa_live.clone());
+    let live_goal = crate::constraint::constraints::Goal::Action(*live_node, fa_live.clone());
     // HS-faithful (Sources.hs:196-216): `solveAllSafeGoals.safeGoal`
     // returns `not (isKUFact fa)` for ActionG (Sources.hs:144-225, see line 202), so
     // HS's saturate-time precompute NEVER picks a KU action goal
@@ -4916,10 +4914,8 @@ fn apply_source_case_premise(
         return Vec::new();
     }
 
-    let live_goal_for_trace = crate::constraint::constraints::Goal::Premise(
-        (*live_node, live_prem_idx),
-        fa_live.clone(),
-    );
+    let live_goal_for_trace =
+        crate::constraint::constraints::Goal::Premise((*live_node, live_prem_idx), fa_live.clone());
     crate::state_trace::emit("applySource_prem_in", Some(&live_goal_for_trace), live_sys);
 
     // A.1 — `rename th0` in matchToGoal (Sources.hs:387-448, see line 409):
@@ -5444,10 +5440,8 @@ fn close_trivial_chains_in_graft(r: &mut crate::constraint::solver::reduction::R
         // Snapshot system; if direct-edge unification contradicts,
         // restore and stop trying.
         let snapshot = r.sys.clone();
-        r.sys.add_edge(crate::constraint::constraints::Edge {
-            src: c,
-            tgt: p,
-        });
+        r.sys
+            .add_edge(crate::constraint::constraints::Edge { src: c, tgt: p });
         let res = r.solve_fact_eqs(
             SplitStrategy::SplitNow,
             &[tamarin_term::rewriting::Equal {
@@ -5554,8 +5548,7 @@ fn graft_case_into_action(
             out.goals_mut().push((renamed_goal, st.clone()));
         }
     }
-    let live_goal =
-        crate::constraint::constraints::Goal::Action(*live_node, fa_live.clone());
+    let live_goal = crate::constraint::constraints::Goal::Action(*live_node, fa_live.clone());
     if let Some(slot) = out.goals_mut().iter_mut().find(|(g, _)| g == &live_goal) {
         // HS-faithful: see the matching gate in `conjoin_refine_arm`.
         // `solveAllSafeGoals.safeGoal` (Sources.hs:144-225, see line 202) excludes KU
@@ -5590,15 +5583,10 @@ fn graft_case_into_action(
     // Out_Initiator's terms, the universal fires, and the case is
     // pruned via contradiction.
     let mut merged_pairs: Vec<_> = out.eq_store.subst.to_list();
-    let existing: std::collections::HashSet<_> =
-        merged_pairs.iter().map(|(v, _)| *v).collect();
+    let existing: std::collections::HashSet<_> = merged_pairs.iter().map(|(v, _)| *v).collect();
     let mut appended_any = false;
     for (lv, lt) in case_sys.eq_store.subst.to_list() {
-        let new_lv = if &lv == abstract_node {
-            *live_node
-        } else {
-            lv
-        };
+        let new_lv = if &lv == abstract_node { *live_node } else { lv };
         if !existing.contains(&new_lv) {
             appended_any = true;
             merged_pairs.push((new_lv, lt));
@@ -5919,9 +5907,7 @@ fn var_occurrences_nodes(
     for (nid, rule) in &nodes_sorted {
         // For (k, v) tuple: "0":p for k (NodeId is just an LVar), "1":p for v.
         // base_ctx is empty, so k = ["0"] and the rule root chain = ["1"].
-        out.entry(*nid)
-            .or_default()
-            .insert(vec!["0".to_string()]);
+        out.entry(*nid).or_default().insert(vec!["0".to_string()]);
         let v_ctx = Ctx {
             seg: std::borrow::Cow::Borrowed("1"),
             parent: None,

--- a/crates/tamarin-theory/src/constraint/solver/sources.rs
+++ b/crates/tamarin-theory/src/constraint/solver/sources.rs
@@ -1814,8 +1814,8 @@ fn eq_modulo_freshness_no_ac(
                 if va.sort != vb.sort {
                     return false;
                 }
-                let ka = ma.get(va).cloned();
-                let kb = mb.get(vb).cloned();
+                let ka = ma.get(va).copied();
+                let kb = mb.get(vb).copied();
                 match (ka, kb) {
                     (Some(x), Some(y)) => x == y,
                     (None, None) => {
@@ -3799,7 +3799,7 @@ fn freshen_system_some_inst(
 
     // Step 2: apply bindings to produce the freshened system.
     let lookup = |v: &tamarin_term::lterm::LVar| -> tamarin_term::lterm::LVar {
-        bindings.get(v).cloned().unwrap_or(*v)
+        bindings.get(v).copied().unwrap_or(*v)
     };
     // For Guarded formulas (VarSpec-based), build a (name, idx) → new (name, idx) map.
     // VarSpec sort hints are preserved unchanged.
@@ -6261,7 +6261,7 @@ fn compute_rename_map(
 /// Apply rename to an LVar; if missing, return as-is (Node-sort vars
 /// without an occurrence in `_sNodes` may not appear in the map).
 fn rn(rename: &RenameMap, v: &tamarin_term::lterm::LVar) -> tamarin_term::lterm::LVar {
-    rename.get(v).cloned().unwrap_or(*v)
+    rename.get(v).copied().unwrap_or(*v)
 }
 
 /// Write a term to the key buffer with renamed vars.
@@ -7012,7 +7012,7 @@ fn write_term_to_key_local(t: &tamarin_term::lterm::LNTerm, rename: &RenameMap, 
     // Same App/Con recursion as `write_term_to_key`, but the Var leaf drops
     // the name (local dedup keys use idx:sort only).
     write_term_to_key_with(t, out, &|v, out| {
-        let rv = rename.get(v).cloned().unwrap_or(*v);
+        let rv = rename.get(v).copied().unwrap_or(*v);
         out.push('v');
         push_u64(out, rv.idx);
         out.push(':');

--- a/crates/tamarin-theory/src/constraint/solver/sources.rs
+++ b/crates/tamarin-theory/src/constraint/solver/sources.rs
@@ -7273,7 +7273,7 @@ mod tests {
         use tamarin_term::lterm::{LSort, LVar};
         let mut s = System::empty();
         let n: NodeId = LVar::new("i", LSort::Node, 0);
-        s.add_goal(Goal::Chain((n.clone(), ConcIdx(0)), (n, PremIdx(0))));
+        s.add_goal(Goal::Chain((n, ConcIdx(0)), (n, PremIdx(0))));
         assert_eq!(unsolved_chain_constraints(&s), 1);
     }
 
@@ -7319,7 +7319,7 @@ mod tests {
     fn precompute_sources_picks_single_producer() {
         use crate::fact::{FactTag, Multiplicity};
         let tag = FactTag::Proto(Multiplicity::Linear, "Foo", 0);
-        let rules = vec![make_rule("MakeFoo", tag.clone())];
+        let rules = vec![make_rule("MakeFoo", tag)];
         let ctx = match ctx_with_rules(rules) {
             Some(c) => c,
             None => return,
@@ -7339,8 +7339,8 @@ mod tests {
         use crate::fact::{FactTag, Multiplicity};
         let tag = FactTag::Proto(Multiplicity::Linear, "Bar", 0);
         let rules = vec![
-            make_rule("MakeBarA", tag.clone()),
-            make_rule("MakeBarB", tag.clone()),
+            make_rule("MakeBarA", tag),
+            make_rule("MakeBarB", tag),
         ];
         let ctx = match ctx_with_rules(rules) {
             Some(c) => c,
@@ -7382,7 +7382,7 @@ mod tests {
         .unwrap();
 
         let a_tag = FactTag::Proto(Multiplicity::Linear, "A", 1);
-        let a_fact = Fact::new(a_tag.clone(), vec![msg_var("x", 0)]);
+        let a_fact = Fact::new(a_tag, vec![msg_var("x", 0)]);
         let init: ProtoRuleE = Rule::new(
             ProtoRuleEInfo::standard("Init"),
             vec![fresh_fact(msg_var("x", 0))],
@@ -7448,7 +7448,7 @@ mod tests {
         // Minimal protocol so there's at least one proto rule (so
         // `precompute_full_sources` actually runs).
         let a_tag = FactTag::Proto(Multiplicity::Linear, "A", 1);
-        let a_fact = Fact::new(a_tag.clone(), vec![msg_var("x", 0)]);
+        let a_fact = Fact::new(a_tag, vec![msg_var("x", 0)]);
         let init: ProtoRuleE = Rule::new(
             ProtoRuleEInfo::standard("Init"),
             vec![fresh_fact(msg_var("x", 0))],
@@ -7488,8 +7488,8 @@ mod tests {
         let tag_a = FactTag::Proto(Multiplicity::Linear, "A", 0);
         let tag_b = FactTag::Proto(Multiplicity::Linear, "B", 0);
         let rules = vec![
-            make_rule("MakeA", tag_a.clone()),
-            make_rule("MakeB", tag_b.clone()),
+            make_rule("MakeA", tag_a),
+            make_rule("MakeB", tag_b),
         ];
         let ctx = match ctx_with_rules(rules) {
             Some(c) => c,
@@ -7539,12 +7539,12 @@ mod tests {
         let mut sys = System::empty();
         sys.invalidate_max_var_idx_cache();
         sys.eq_store_mut().subst = Subst::from_list(vec![
-            (t1.clone(), Term::Lit(Lit::Var(pub_a))),
-            (m19.clone(), Term::Lit(Lit::Var(pub_b))),
-            (sk28.clone(), Term::Lit(Lit::Var(t2.clone()))),
+            (t1, Term::Lit(Lit::Var(pub_a))),
+            (m19, Term::Lit(Lit::Var(pub_b))),
+            (sk28, Term::Lit(Lit::Var(t2))),
         ]);
 
-        let stable: BTreeSet<LVar> = [t1.clone(), t2.clone()].into_iter().collect();
+        let stable: BTreeSet<LVar> = [t1, t2].into_iter().collect();
         restrict_eq_store_to_stable_vars(&mut sys, &stable);
 
         // t1 binding kept; m19 + sk28 bindings dropped.
@@ -7587,11 +7587,11 @@ mod tests {
         let mut sys = System::empty();
         sys.invalidate_max_var_idx_cache();
         sys.eq_store_mut().subst = Subst::from_list(vec![
-            (t1.clone(), Term::Lit(Lit::Var(e10.clone()))),
-            (e10.clone(), Term::Lit(Lit::Var(blind_arg.clone()))),
+            (t1, Term::Lit(Lit::Var(e10))),
+            (e10, Term::Lit(Lit::Var(blind_arg))),
         ]);
 
-        let stable: BTreeSet<LVar> = [t1.clone()].into_iter().collect();
+        let stable: BTreeSet<LVar> = [t1].into_iter().collect();
         restrict_eq_store_to_stable_vars(&mut sys, &stable);
 
         // t.1's binding must be exactly e.10 (the var), NOT chain-chased

--- a/crates/tamarin-theory/src/constraint/solver/sources.rs
+++ b/crates/tamarin-theory/src/constraint/solver/sources.rs
@@ -79,9 +79,9 @@ fn collect_node_and_fact_frees(
 ) -> std::collections::BTreeSet<tamarin_term::lterm::LVar> {
     use tamarin_term::lterm::HasFrees;
     let mut s = std::collections::BTreeSet::new();
-    s.insert(live_node.clone());
+    s.insert(*live_node);
     fa_live.for_each_free(&mut |v: &tamarin_term::lterm::LVar| {
-        s.insert(v.clone());
+        s.insert(*v);
     });
     s
 }
@@ -92,7 +92,7 @@ fn collect_node_and_fact_frees(
 fn collect_node_ids(
     sys: &System,
 ) -> std::collections::BTreeSet<crate::constraint::constraints::NodeId> {
-    sys.nodes.iter().map(|(n, _)| n.clone()).collect()
+    sys.nodes.iter().map(|(n, _)| *n).collect()
 }
 
 /// Grafted-edge producer-conclusion ⇆ consumer-premise fact equalities.
@@ -699,7 +699,7 @@ pub fn precompute_sources(
     let mut counts: BTreeMap<crate::fact::FactTag, u32> = BTreeMap::new();
     for o in &ctx.rules {
         for c in &o.rule.conclusions {
-            *counts.entry(c.tag.clone()).or_insert(0) += 1;
+            *counts.entry(c.tag).or_insert(0) += 1;
         }
     }
     let mut out = Vec::new();
@@ -707,14 +707,14 @@ pub fn precompute_sources(
         for c in &o.rule.conclusions {
             if counts.get(&c.tag).copied() == Some(1) {
                 out.push(UniqueSource {
-                    fact_tag: c.tag.clone(),
+                    fact_tag: c.tag,
                     rule_name: o.name().to_string(),
                 });
             }
         }
     }
     // Dedup.
-    out.sort_by(|a, b| a.fact_tag.cmp(&b.fact_tag));
+    out.sort_by_key(|a| a.fact_tag);
     out.dedup_by(|a, b| a.fact_tag == b.fact_tag);
     out
 }
@@ -754,7 +754,7 @@ pub fn precompute_full_sources(
     for o in &ctx.rules {
         for fa in o.rule.premises.iter().chain(o.rule.conclusions.iter()) {
             if matches!(&fa.tag, FactTag::Proto(_, _, _)) {
-                tags.insert(fa.tag.clone());
+                tags.insert(fa.tag);
             }
         }
     }
@@ -795,8 +795,8 @@ pub fn precompute_full_sources(
                 ))
             })
             .collect();
-        let abstract_fact = Fact::new(tag.clone(), terms);
-        let goal = Goal::Premise((goal_node.clone(), PremIdx(0)), abstract_fact.clone());
+        let abstract_fact = Fact::new(tag, terms);
+        let goal = Goal::Premise((goal_node, PremIdx(0)), abstract_fact.clone());
         // HS-faithful: defer `initialSource`'s `solve_premise_goal`
         // call to `Source::cases(ctx)`'s first invocation.  No work
         // done here, no `[EXEC] solveGoal kind=Premise ...` line
@@ -948,7 +948,7 @@ pub fn precompute_full_sources(
     }
     for pat in ku_patterns {
         let ku_fact = crate::fact::ku_fact(pat.clone());
-        let goal = Goal::Action(goal_node.clone(), ku_fact.clone());
+        let goal = Goal::Action(goal_node, ku_fact.clone());
         // HS-faithful lazy: defer `solve_action_goal` + normalisation
         // to `Source::cases(ctx)`.  No work done here.
         out.push(Source::lazy(goal));
@@ -1440,7 +1440,7 @@ fn refine_one_source(
     let mut stable_vars: std::collections::BTreeSet<tamarin_term::lterm::LVar> =
         std::collections::BTreeSet::new();
     goal_walk_frees(&src.goal, &mut |v| {
-        stable_vars.insert(v.clone());
+        stable_vars.insert(*v);
     });
     let all_cases = src.cases_take_list();
     // HS `refineSource` (Sources.hs:144-225, see line 162): `fs = avoid th` — the fresh seed
@@ -1821,8 +1821,8 @@ fn eq_modulo_freshness_no_ac(
                     (None, None) => {
                         let k = *next;
                         *next += 1;
-                        ma.insert(va.clone(), k);
-                        mb.insert(vb.clone(), k);
+                        ma.insert(*va, k);
+                        mb.insert(*vb, k);
                         true
                     }
                     _ => false,
@@ -2319,7 +2319,7 @@ fn run_solve_all_safe_goals_disj_with_progress(
                             return None;
                         }
                     }
-                    Some((i.clone(), fa.clone()))
+                    Some((*i, fa.clone()))
                 }
                 _ => None,
             })
@@ -2462,7 +2462,7 @@ fn run_solve_all_safe_goals_disj_with_progress(
             };
             if has_fresh_var {
                 let live_goal_action =
-                    crate::constraint::constraints::Goal::Action(i.clone(), fa.clone());
+                    crate::constraint::constraints::Goal::Action(i, fa.clone());
                 for (g, st) in sub.sys.goals_mut().iter_mut() {
                     if g == &live_goal_action {
                         st.solved = true;
@@ -2750,7 +2750,7 @@ fn freshen_system(
         avoid_max.saturating_add(1)
     };
     let shift_lvar = |v: &tamarin_term::lterm::LVar| {
-        let mut v2 = v.clone();
+        let mut v2 = *v;
         v2.idx = v2.idx.saturating_add(shift);
         v2
     };
@@ -3014,7 +3014,7 @@ pub fn solve_with_source_cases_action_with_ctx(
     })?;
 
     let abstract_orig = match &src.goal {
-        Goal::Action(n, _) => n.clone(),
+        Goal::Action(n, _) => *n,
         _ => return None,
     };
 
@@ -3114,9 +3114,9 @@ pub fn solve_with_source_cases_action_with_ctx(
                 use tamarin_term::lterm::HasFrees;
                 let stable_vars: std::collections::BTreeSet<tamarin_term::lterm::LVar> = {
                     let mut s = std::collections::BTreeSet::new();
-                    s.insert(goal_node.clone());
+                    s.insert(*goal_node);
                     fa_live.for_each_free(&mut |v: &tamarin_term::lterm::LVar| {
-                        s.insert(v.clone());
+                        s.insert(*v);
                     });
                     s
                 };
@@ -3193,7 +3193,7 @@ pub fn solve_with_source_cases_action_with_ctx(
             let case_label = name.clone();
             let renamed = freshen_system(&case_sys, avoid_max, ctx_opt.map(|c| &c.maude));
             let abstract_renamed = {
-                let mut v = abstract_orig.clone();
+                let mut v = abstract_orig;
                 v.idx = v.idx.saturating_add(avoid_max.saturating_add(1));
                 v
             };
@@ -3387,9 +3387,9 @@ fn freshen_system_keep_with_shift(
     };
     let shift_lvar = |v: &tamarin_term::lterm::LVar| {
         if keep.contains(v) {
-            v.clone()
+            *v
         } else {
-            let mut v2 = v.clone();
+            let mut v2 = *v;
             v2.idx = shift_idx(v2.idx);
             v2
         }
@@ -3604,7 +3604,7 @@ fn freshen_system_some_inst(
     let mut bindings: BTreeMap<tamarin_term::lterm::LVar, tamarin_term::lterm::LVar> =
         BTreeMap::new();
     for v in keep {
-        bindings.insert(v.clone(), v.clone());
+        bindings.insert(*v, *v);
     }
     let import_var =
         |v: &tamarin_term::lterm::LVar,
@@ -3618,7 +3618,7 @@ fn freshen_system_some_inst(
                 sort: v.sort,
                 idx: new_idx,
             };
-            bindings.insert(v.clone(), new_v);
+            bindings.insert(*v, new_v);
         };
 
     // sNodes: BTreeMap-equivalent iteration by NodeId order.  Rust's
@@ -3628,7 +3628,7 @@ fn freshen_system_some_inst(
         crate::constraint::constraints::NodeId,
         crate::rule::RuleACInst,
     )> = sys.nodes.iter().collect();
-    sorted_nodes.sort_by(|a, b| a.0.cmp(&b.0));
+    sorted_nodes.sort_by_key(|a| a.0);
     for (id, rule) in &sorted_nodes {
         import_var(id, &mut bindings);
         // HS Rule HasFrees order: info, premises, conclusions, actions,
@@ -3730,17 +3730,14 @@ fn freshen_system_some_inst(
          bindings: &mut BTreeMap<tamarin_term::lterm::LVar, tamarin_term::lterm::LVar>| {
             let _ = crate::guarded::map_lvars_in_guarded(g, |v: &tamarin_parser::ast::VarSpec| {
                 if let Some(lv) = vspec_to_lvar(v) {
-                    if !bindings.contains_key(&lv) {
+                    bindings.entry(lv).or_insert_with(|| {
                         let new_idx = maude.reserve_idxs(1);
-                        bindings.insert(
-                            lv.clone(),
-                            tamarin_term::lterm::LVar {
+                        tamarin_term::lterm::LVar {
                                 name: lv.name,
                                 sort: lv.sort,
                                 idx: new_idx,
-                            },
-                        );
-                    }
+                            }
+                    });
                 }
                 v.clone()
             });
@@ -3803,7 +3800,7 @@ fn freshen_system_some_inst(
 
     // Step 2: apply bindings to produce the freshened system.
     let lookup = |v: &tamarin_term::lterm::LVar| -> tamarin_term::lterm::LVar {
-        bindings.get(v).cloned().unwrap_or_else(|| v.clone())
+        bindings.get(v).cloned().unwrap_or(*v)
     };
     // For Guarded formulas (VarSpec-based), build a (name, idx) → new (name, idx) map.
     // VarSpec sort hints are preserved unchanged.
@@ -4157,7 +4154,7 @@ fn refine_source_case_action(
 
     // Pull the abstract `cdGoal` (NodeId + LNFact) out of `src`.
     let (abstract_node_orig, abstract_action_orig) = match &src.goal {
-        crate::constraint::constraints::Goal::Action(n, fa) => (n.clone(), fa.clone()),
+        crate::constraint::constraints::Goal::Action(n, fa) => (*n, fa.clone()),
         _ => {
             return Vec::new();
         }
@@ -4169,7 +4166,7 @@ fn refine_source_case_action(
     }
 
     let live_goal_for_trace =
-        crate::constraint::constraints::Goal::Action(live_node.clone(), fa_live.clone());
+        crate::constraint::constraints::Goal::Action(*live_node, fa_live.clone());
     crate::state_trace::emit("applySource_in", Some(&live_goal_for_trace), live_sys);
 
     // ---------------------------------------------------------------
@@ -4219,7 +4216,7 @@ fn refine_source_case_action(
         None => 0,
     };
     let shift_lvar = |v: &tamarin_term::lterm::LVar| {
-        let mut v2 = v.clone();
+        let mut v2 = *v;
         let n = v2.idx as i128 + rename_shift;
         v2.idx = if n < 0 { 0 } else { n as u64 };
         v2
@@ -4272,8 +4269,8 @@ fn refine_source_case_action(
         pairs.push((lt.clone(), pt.clone()));
     }
     pairs.push((
-        tamarin_term::term::Term::Lit(tamarin_term::vterm::Lit::Var(live_node.clone())),
-        tamarin_term::term::Term::Lit(tamarin_term::vterm::Lit::Var(renamed_abstract_node.clone())),
+        tamarin_term::term::Term::Lit(tamarin_term::vterm::Lit::Var(*live_node)),
+        tamarin_term::term::Term::Lit(tamarin_term::vterm::Lit::Var(renamed_abstract_node)),
     ));
 
     // HS-faithful `doMatch (faTerm matchFact faPat <> iTerm matchLVar
@@ -4582,7 +4579,7 @@ fn conjoin_refine_arm(
     } = arm;
 
     let live_goal_for_trace =
-        crate::constraint::constraints::Goal::Action(live_node.clone(), fa_live.clone());
+        crate::constraint::constraints::Goal::Action(*live_node, fa_live.clone());
 
     // Fourth tuple element: HS FreshT-threading (task #23, A(ii)) —
     // the OUTPUT arm's continuation counter (this branch's fork + its
@@ -4603,7 +4600,7 @@ fn conjoin_refine_arm(
         r.maude = m.clone();
     }
     let live_goal =
-        crate::constraint::constraints::Goal::Action(live_node.clone(), fa_live.clone());
+        crate::constraint::constraints::Goal::Action(*live_node, fa_live.clone());
     // HS-faithful (Sources.hs:196-216): `solveAllSafeGoals.safeGoal`
     // returns `not (isKUFact fa)` for ActionG (Sources.hs:144-225, see line 202), so
     // HS's saturate-time precompute NEVER picks a KU action goal
@@ -4908,7 +4905,7 @@ fn apply_source_case_premise(
     use tamarin_term::lterm::HasFrees;
 
     let (abstract_node_orig, abstract_prem_idx_orig, abstract_prem_fact_orig) = match &src.goal {
-        crate::constraint::constraints::Goal::Premise((n, p), fa) => (n.clone(), *p, fa.clone()),
+        crate::constraint::constraints::Goal::Premise((n, p), fa) => (*n, *p, fa.clone()),
         _ => {
             return Vec::new();
         }
@@ -4920,7 +4917,7 @@ fn apply_source_case_premise(
     }
 
     let live_goal_for_trace = crate::constraint::constraints::Goal::Premise(
-        (live_node.clone(), live_prem_idx),
+        (*live_node, live_prem_idx),
         fa_live.clone(),
     );
     crate::state_trace::emit("applySource_prem_in", Some(&live_goal_for_trace), live_sys);
@@ -4953,7 +4950,7 @@ fn apply_source_case_premise(
         None => 0,
     };
     let shift_lvar = |v: &tamarin_term::lterm::LVar| {
-        let mut v2 = v.clone();
+        let mut v2 = *v;
         let n = v2.idx as i128 + rename_shift;
         v2.idx = if n < 0 { 0 } else { n as u64 };
         v2
@@ -4987,8 +4984,8 @@ fn apply_source_case_premise(
         pairs.push((lt.clone(), pt.clone()));
     }
     pairs.push((
-        tamarin_term::term::Term::Lit(tamarin_term::vterm::Lit::Var(live_node.clone())),
-        tamarin_term::term::Term::Lit(tamarin_term::vterm::Lit::Var(renamed_abstract_node.clone())),
+        tamarin_term::term::Term::Lit(tamarin_term::vterm::Lit::Var(*live_node)),
+        tamarin_term::term::Term::Lit(tamarin_term::vterm::Lit::Var(renamed_abstract_node)),
     ));
     // HS-faithful `doMatch` (Sources.hs:387-448, see line 390,414) — see the action-path
     // twin above: only the `NeedsAc` (HS `Left ACProblem`) branch shells
@@ -5043,16 +5040,16 @@ fn apply_source_case_premise(
     // Faithful behaviour: rewrite edges only; leave goals at the source idx.
     let mut renamed_case = renamed_case;
     let pat_prem: (tamarin_term::lterm::LVar, crate::rule::PremIdx) =
-        (renamed_abstract_node.clone(), abstract_prem_idx_orig);
+        (renamed_abstract_node, abstract_prem_idx_orig);
     let new_prem: (tamarin_term::lterm::LVar, crate::rule::PremIdx) =
-        (renamed_abstract_node.clone(), live_prem_idx);
+        (renamed_abstract_node, live_prem_idx);
     // In-place edge-endpoint rewrite through `content_mut()` — the
     // conservative door bumps `content_stamp` (and, harmlessly, invalidates
     // the caches: `renamed_case` was freshened, marker already cleared, and it
     // is about to be wrapped in a `Reduction` and refined).
     for e in renamed_case.content_mut().edges.iter_mut() {
         if e.tgt == pat_prem {
-            e.tgt = new_prem.clone();
+            e.tgt = new_prem;
         }
     }
 
@@ -5184,7 +5181,7 @@ fn apply_source_case_premise(
         let mut r = Reduction::new(ctx, live_sys.clone());
         r.maude = red_m.clone();
         let live_goal = crate::constraint::constraints::Goal::Premise(
-            (live_node.clone(), live_prem_idx),
+            (*live_node, live_prem_idx),
             fa_live.clone(),
         );
         if let Some(slot) = r.sys.goals_mut().iter_mut().find(|(g, _)| g == &live_goal) {
@@ -5432,13 +5429,13 @@ fn close_trivial_chains_in_graft(r: &mut crate::constraint::solver::reduction::R
             // what HS leaves open; only chains HS itself auto-handles
             // (union-all-known) remain eligible for direct-edge closure.
             if crate::constraint::solver::goals::is_open_for_saturate_with(
-                &Goal::Chain(c.clone(), p.clone()),
+                &Goal::Chain(*c, *p),
                 &r.sys,
                 &sat_adj,
             ) {
                 return None;
             }
-            Some((c.clone(), p.clone(), fa_conc, fa_prem))
+            Some((*c, *p, fa_conc, fa_prem))
         });
         let Some((c, p, fa_conc, fa_prem)) = candidate else {
             break;
@@ -5448,8 +5445,8 @@ fn close_trivial_chains_in_graft(r: &mut crate::constraint::solver::reduction::R
         // restore and stop trying.
         let snapshot = r.sys.clone();
         r.sys.add_edge(crate::constraint::constraints::Edge {
-            src: c.clone(),
-            tgt: p.clone(),
+            src: c,
+            tgt: p,
         });
         let res = r.solve_fact_eqs(
             SplitStrategy::SplitNow,
@@ -5503,9 +5500,9 @@ fn graft_case_into_action(
     let mut out = live_sys.clone();
     let rename_node = |n: &crate::constraint::constraints::NodeId| {
         if n == abstract_node {
-            live_node.clone()
+            *live_node
         } else {
-            n.clone()
+            *n
         }
     };
     for (id, rule) in case_sys.nodes.iter() {
@@ -5558,7 +5555,7 @@ fn graft_case_into_action(
         }
     }
     let live_goal =
-        crate::constraint::constraints::Goal::Action(live_node.clone(), fa_live.clone());
+        crate::constraint::constraints::Goal::Action(*live_node, fa_live.clone());
     if let Some(slot) = out.goals_mut().iter_mut().find(|(g, _)| g == &live_goal) {
         // HS-faithful: see the matching gate in `conjoin_refine_arm`.
         // `solveAllSafeGoals.safeGoal` (Sources.hs:144-225, see line 202) excludes KU
@@ -5594,11 +5591,11 @@ fn graft_case_into_action(
     // pruned via contradiction.
     let mut merged_pairs: Vec<_> = out.eq_store.subst.to_list();
     let existing: std::collections::HashSet<_> =
-        merged_pairs.iter().map(|(v, _)| v.clone()).collect();
+        merged_pairs.iter().map(|(v, _)| *v).collect();
     let mut appended_any = false;
     for (lv, lt) in case_sys.eq_store.subst.to_list() {
         let new_lv = if &lv == abstract_node {
-            live_node.clone()
+            *live_node
         } else {
             lv
         };
@@ -5803,7 +5800,7 @@ fn var_occurrences_nodes(
     ) {
         match t {
             Term::Lit(Lit::Var(v)) => {
-                out.entry(v.clone()).or_default().insert(ctx.materialize());
+                out.entry(*v).or_default().insert(ctx.materialize());
             }
             Term::Lit(Lit::Con(_)) => {}
             Term::App(sym, args) => {
@@ -5917,12 +5914,12 @@ fn var_occurrences_nodes(
     // order (Ord LVar on NodeId) — HS's M.foldrWithKey iterates ASC.
     let mut nodes_sorted: Vec<&(tamarin_term::lterm::LVar, crate::rule::RuleACInst)> =
         sys.nodes.iter().collect();
-    nodes_sorted.sort_by(|a, b| a.0.cmp(&b.0));
+    nodes_sorted.sort_by_key(|a| a.0);
     let mut out: BTreeMap<LVar, BTreeSet<Vec<String>>> = BTreeMap::new();
     for (nid, rule) in &nodes_sorted {
         // For (k, v) tuple: "0":p for k (NodeId is just an LVar), "1":p for v.
         // base_ctx is empty, so k = ["0"] and the rule root chain = ["1"].
-        out.entry((*nid).clone())
+        out.entry(*nid)
             .or_default()
             .insert(vec!["0".to_string()]);
         let v_ctx = Ctx {
@@ -6025,7 +6022,7 @@ fn system_walk_frees(
     // a: sNodes (Map NodeId RuleACInst) — BTreeMap-key order.
     let mut nodes_sorted: Vec<&(tamarin_term::lterm::LVar, crate::rule::RuleACInst)> =
         sys.nodes.iter().collect();
-    nodes_sorted.sort_by(|a, b| a.0.cmp(&b.0));
+    nodes_sorted.sort_by_key(|a| a.0);
     for (nid, rule) in &nodes_sorted {
         push(nid);
         rule.for_each_free(push);
@@ -6232,7 +6229,7 @@ fn compute_rename_map(
     let mut rename: RenameMap = RenameMap::default();
     // Step 1: stable vars bind to themselves.
     for v in stable_vars {
-        rename.insert(v.clone(), v.clone());
+        rename.insert(*v, *v);
     }
     // Step 2: fresh state = avoid stableVars.
     let mut fresh_state = tamarin_utils::fresh::FastFreshState::nothing_used();
@@ -6255,7 +6252,7 @@ fn compute_rename_map(
                 sort: v.sort,
                 idx: new_idx,
             };
-            rename.insert(v.clone(), new_v);
+            rename.insert(*v, new_v);
         };
     // Step 3: orderedVars sys — varOccurences from nodes ONLY,
     // sorted by occurrence set, filtered to non-Node sort.
@@ -6278,7 +6275,7 @@ fn compute_rename_map(
 /// Apply rename to an LVar; if missing, return as-is (Node-sort vars
 /// without an occurrence in `_sNodes` may not appear in the map).
 fn rn(rename: &RenameMap, v: &tamarin_term::lterm::LVar) -> tamarin_term::lterm::LVar {
-    rename.get(v).cloned().unwrap_or_else(|| v.clone())
+    rename.get(v).cloned().unwrap_or(*v)
 }
 
 /// Write a term to the key buffer with renamed vars.
@@ -6811,7 +6808,7 @@ fn compute_compare_systems_key(
             .drain(..)
             .map(|(v, t)| (rn(&rename, &v), t))
             .collect();
-    subst_keyed.sort_by(|a, b| a.0.cmp(&b.0));
+    subst_keyed.sort_by_key(|a| a.0);
     for (v, t) in &subst_keyed {
         push_u64(&mut out, v.idx);
         out.push(':');
@@ -6843,7 +6840,7 @@ fn compute_compare_systems_key(
                 .into_iter()
                 .map(|(v, t)| (rn(&rename, &v), t))
                 .collect();
-            entries.sort_by(|a, b| a.0.cmp(&b.0));
+            entries.sort_by_key(|a| a.0);
             for (v, t) in &entries {
                 push_u64(&mut scratch, v.idx);
                 scratch.push(':');
@@ -6860,7 +6857,7 @@ fn compute_compare_systems_key(
                     |v: &tamarin_term::lterm::LVar, m: &mut RenameMap, n: &mut u64| {
                         if !m.contains_key(v) {
                             m.insert(
-                                v.clone(),
+                                *v,
                                 tamarin_term::lterm::LVar {
                                     name: "",
                                     sort: v.sort,
@@ -7029,7 +7026,7 @@ fn write_term_to_key_local(t: &tamarin_term::lterm::LNTerm, rename: &RenameMap, 
     // Same App/Con recursion as `write_term_to_key`, but the Var leaf drops
     // the name (local dedup keys use idx:sort only).
     write_term_to_key_with(t, out, &|v, out| {
-        let rv = rename.get(v).cloned().unwrap_or_else(|| v.clone());
+        let rv = rename.get(v).cloned().unwrap_or(*v);
         out.push('v');
         push_u64(out, rv.idx);
         out.push(':');

--- a/crates/tamarin-theory/src/constraint/system.rs
+++ b/crates/tamarin-theory/src/constraint/system.rs
@@ -278,7 +278,7 @@ impl Clone for SystemContent {
             formulas: self.formulas.clone(),
             solved_formulas: self.solved_formulas.clone(),
             lemmas: self.lemmas.clone(),
-            last_atom: self.last_atom.clone(),
+            last_atom: self.last_atom,
             eq_store: SealedEqStore(self.eq_store.0.clone()),
             subterm_store: self.subterm_store.clone(),
             goals: self.goals.clone(),
@@ -1143,7 +1143,7 @@ impl System {
             for (j, fa) in ru.enumerate_premises() {
                 if let Some(ms) = crate::fact::proto_or_in_fact_view(fa) {
                     for (k, m) in ms.into_iter().enumerate() {
-                        out.push((i.clone(), j, k, m));
+                        out.push((*i, j, k, m));
                     }
                 }
             }
@@ -1166,7 +1166,7 @@ impl System {
                 continue;
             }
             if let Goal::Chain(from, to) = g {
-                out.push((from.clone(), to.clone()));
+                out.push((*from, *to));
             }
         }
         out
@@ -1187,7 +1187,7 @@ impl System {
                 continue;
             }
             if let Goal::Premise(premidx, fa) = g {
-                out.push((premidx.clone(), fa.clone()));
+                out.push((*premidx, fa.clone()));
             }
         }
         out
@@ -1592,7 +1592,7 @@ impl System {
     pub fn build_less_index(&self) -> LessIndex {
         let mut idx: LessIndex = tamarin_utils::FastMap::default();
         for (i, la) in self.less_atoms.iter().enumerate() {
-            idx.entry((la.smaller.clone(), la.larger.clone()))
+            idx.entry((la.smaller, la.larger))
                 .or_insert(i);
         }
         idx
@@ -1616,7 +1616,7 @@ impl System {
     /// the last indexed insert (within `enforce_fresh_ordering_pass` the only
     /// mutators are these calls — Maude unifiability queries are read-only).
     pub fn add_less_indexed(&mut self, l: LessAtom, idx: &mut LessIndex) -> bool {
-        let key = (l.smaller.clone(), l.larger.clone());
+        let key = (l.smaller, l.larger);
         if let Some(&pos) = idx.get(&key) {
             self.content.less_atoms[pos] = l;
             false
@@ -1651,14 +1651,14 @@ impl System {
         let mut adj: std::collections::BTreeMap<NodeId, Vec<NodeId>> =
             std::collections::BTreeMap::new();
         for l in &self.less_atoms {
-            adj.entry(l.smaller.clone())
+            adj.entry(l.smaller)
                 .or_default()
-                .push(l.larger.clone());
+                .push(l.larger);
         }
         for e in &self.edges {
-            adj.entry(e.src.0.clone())
+            adj.entry(e.src.0)
                 .or_default()
-                .push(e.tgt.0.clone());
+                .push(e.tgt.0);
         }
         // HS-faithful `unsolvedChains` contribution to rawEdgeRel
         // (`System.hs`).
@@ -1667,7 +1667,7 @@ impl System {
                 continue;
             }
             if let crate::constraint::constraints::Goal::Chain(c, p) = g {
-                adj.entry(c.0.clone()).or_default().push(p.0.clone());
+                adj.entry(c.0).or_default().push(p.0);
             }
         }
         PrebuiltAdj { adj }
@@ -1694,16 +1694,16 @@ impl System {
         // BFS from i until j.
         let mut frontier: std::collections::VecDeque<NodeId> = std::collections::VecDeque::new();
         let mut visited: std::collections::BTreeSet<NodeId> = std::collections::BTreeSet::new();
-        frontier.push_back(i.clone());
-        visited.insert(i.clone());
+        frontier.push_back(*i);
+        visited.insert(*i);
         while let Some(n) = frontier.pop_front() {
             if let Some(nbrs) = adj.get(&n) {
                 for nb in nbrs {
                     if nb == j {
                         return true;
                     }
-                    if visited.insert(nb.clone()) {
-                        frontier.push_back(nb.clone());
+                    if visited.insert(*nb) {
+                        frontier.push_back(*nb);
                     }
                 }
             }

--- a/crates/tamarin-theory/src/constraint/system.rs
+++ b/crates/tamarin-theory/src/constraint/system.rs
@@ -1592,8 +1592,7 @@ impl System {
     pub fn build_less_index(&self) -> LessIndex {
         let mut idx: LessIndex = tamarin_utils::FastMap::default();
         for (i, la) in self.less_atoms.iter().enumerate() {
-            idx.entry((la.smaller, la.larger))
-                .or_insert(i);
+            idx.entry((la.smaller, la.larger)).or_insert(i);
         }
         idx
     }
@@ -1651,14 +1650,10 @@ impl System {
         let mut adj: std::collections::BTreeMap<NodeId, Vec<NodeId>> =
             std::collections::BTreeMap::new();
         for l in &self.less_atoms {
-            adj.entry(l.smaller)
-                .or_default()
-                .push(l.larger);
+            adj.entry(l.smaller).or_default().push(l.larger);
         }
         for e in &self.edges {
-            adj.entry(e.src.0)
-                .or_default()
-                .push(e.tgt.0);
+            adj.entry(e.src.0).or_default().push(e.tgt.0);
         }
         // HS-faithful `unsolvedChains` contribution to rawEdgeRel
         // (`System.hs`).

--- a/crates/tamarin-theory/src/elaborate.rs
+++ b/crates/tamarin-theory/src/elaborate.rs
@@ -1564,7 +1564,7 @@ fn compute_new_vars(
 fn collect_vars(t: &tamarin_term::lterm::LNTerm, out: &mut BTreeSet<LVar>) {
     match t {
         Term::Lit(Lit::Var(v)) => {
-            out.insert(v.clone());
+            out.insert(*v);
         }
         Term::Lit(_) => {}
         Term::App(_, args) => {

--- a/crates/tamarin-theory/src/fact.rs
+++ b/crates/tamarin-theory/src/fact.rs
@@ -23,7 +23,7 @@ pub enum Multiplicity {
     Linear,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum FactTag {
     /// A protocol fact: `ProtoFact(multiplicity, name, arity)`.
     /// Interned `&'static str` (see `tamarin_term::intern`): pointer-copy

--- a/crates/tamarin-theory/src/fact.rs
+++ b/crates/tamarin-theory/src/fact.rs
@@ -268,7 +268,7 @@ impl<T> Fact<T> {
     /// same recompute guidance applies if a hot LNFact producer routes here.
     pub fn map_ref<U>(&self, f: impl FnMut(&T) -> U) -> Fact<U> {
         Fact {
-            tag: self.tag.clone(),
+            tag: self.tag,
             annotations: self.annotations.clone(),
             terms: self.terms.iter().map(f).collect(),
             bloom: u64::MAX,
@@ -282,7 +282,7 @@ impl<T> Fact<T> {
     pub fn try_map_ref<U, E>(&self, f: impl FnMut(&T) -> Result<U, E>) -> Result<Fact<U>, E> {
         let terms: Result<Vec<U>, E> = self.terms.iter().map(f).collect();
         Ok(Fact {
-            tag: self.tag.clone(),
+            tag: self.tag,
             annotations: self.annotations.clone(),
             terms: terms?.into(),
             bloom: u64::MAX,

--- a/crates/tamarin-theory/src/fact.rs
+++ b/crates/tamarin-theory/src/fact.rs
@@ -749,7 +749,7 @@ mod tests {
             let b2 = fact_fingerprints(&fa.terms).0;
             assert_eq!(b, b2);
             // A structurally-equal rebuild gets an equal bloom.
-            let fa2 = Fact::fresh(fa.tag.clone(), fa.terms.to_vec());
+            let fa2 = Fact::fresh(fa.tag, fa.terms.to_vec());
             assert_eq!(fa.bloom(), fa2.bloom());
         }
     }

--- a/crates/tamarin-theory/src/guarded.rs
+++ b/crates/tamarin-theory/src/guarded.rs
@@ -1124,7 +1124,7 @@ fn map_guarded_atoms<F: FnMut(u32, &GAtom) -> GAtom>(g: &Guarded, f: &mut F) -> 
             } => {
                 let new_depth = depth + vars.len() as u32;
                 Guarded::GGuarded {
-                    qua: qua.clone(),
+                    qua: *qua,
                     vars: vars.clone(),
                     guards: guards.iter().map(|a| f(new_depth, a)).collect(),
                     body: std::sync::Arc::new(rec(body, new_depth, f)),
@@ -1203,7 +1203,7 @@ pub fn normalise_guarded_cow(g: &Guarded) -> Option<Guarded> {
         // Only `body` can change; qua/vars/guards are cloned verbatim.
         {
             normalise_guarded_cow(body).map(|b| Guarded::GGuarded {
-                qua: qua.clone(),
+                qua: *qua,
                 vars: vars.clone(),
                 guards: guards.clone(),
                 body: std::sync::Arc::new(b),
@@ -1868,7 +1868,7 @@ pub fn normalize_sort_hints(g: &Guarded) -> Guarded {
                 guards,
                 body,
             } => Guarded::GGuarded {
-                qua: qua.clone(),
+                qua: *qua,
                 vars: vars.iter().map(norm_binding).collect(),
                 guards: guards.iter().map(norm_atom).collect(),
                 body: std::sync::Arc::new(rec(body)),
@@ -2092,7 +2092,7 @@ fn cac_rec_guarded_cow(g: &Guarded, cmp: GCmp) -> Option<Guarded> {
             cac_rec_guarded_cow(body, cmp),
         )
         .map(|(guards, body)| Guarded::GGuarded {
-            qua: qua.clone(),
+            qua: *qua,
             vars: vars.clone(),
             guards,
             body: std::sync::Arc::new(body),
@@ -2246,7 +2246,7 @@ pub fn subst_guarded_cow(g: &Guarded, s: &VarSubst) -> Option<Guarded> {
             subst_guarded_cow(body, s),
         )
         .map(|(guards, body)| Guarded::GGuarded {
-            qua: qua.clone(),
+            qua: *qua,
             vars: vars.clone(),
             guards,
             body: std::sync::Arc::new(body),

--- a/crates/tamarin-theory/src/guarded.rs
+++ b/crates/tamarin-theory/src/guarded.rs
@@ -45,7 +45,7 @@ pub use crate::guarded_types::{
 // Guarded data type
 // =============================================================================
 
-#[derive(Debug, Clone, PartialEq, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Hash)]
 pub enum Quant {
     All,
     Ex,

--- a/crates/tamarin-theory/src/intruder_rules.rs
+++ b/crates/tamarin-theory/src/intruder_rules.rs
@@ -972,7 +972,7 @@ fn variants_intruder_with(
     // is applied to.
     // `restrict` key-set is loop-invariant (`packed_frees` never mutates), so
     // materialise the `Vec<LVar>` once rather than per variant subst.
-    let packed_frees_vec: Vec<LVar> = packed_frees.iter().cloned().collect();
+    let packed_frees_vec: Vec<LVar> = packed_frees.iter().copied().collect();
     let cleaned: Vec<LNSubstVFresh> = raw_substs
         .into_iter()
         .map(|pairs| {

--- a/crates/tamarin-theory/src/intruder_rules.rs
+++ b/crates/tamarin-theory/src/intruder_rules.rs
@@ -1036,7 +1036,7 @@ fn variants_intruder_with(
                 .map(|f| {
                     // norm/subst rebuild — frees can change; recompute the bloom.
                     let terms: Vec<LNTerm> = f.terms.iter().map(|t| norm_t(t.clone())).collect();
-                    LNFact::fresh_annotated(f.tag.clone(), f.annotations.clone(), terms)
+                    LNFact::fresh_annotated(f.tag, f.annotations.clone(), terms)
                 })
                 .collect()
         };
@@ -1221,14 +1221,14 @@ pub fn equal_rule_up_to_renaming(
     let vars_r1: Vec<LVar> = {
         let mut s: std::collections::BTreeSet<LVar> = std::collections::BTreeSet::new();
         r1.for_each_free(&mut |v| {
-            s.insert(v.clone());
+            s.insert(*v);
         });
         s.into_iter().collect()
     };
     let vars_r2: Vec<LVar> = {
         let mut s: std::collections::BTreeSet<LVar> = std::collections::BTreeSet::new();
         r2.for_each_free(&mut |v| {
-            s.insert(v.clone());
+            s.insert(*v);
         });
         s.into_iter().collect()
     };
@@ -1294,7 +1294,7 @@ pub(crate) fn norm_rule(
     let norm_fact = |f: &LNFact| -> LNFact {
         // norm rebuild — frees can change; recompute the bloom.
         let terms: Vec<LNTerm> = f.terms.iter().map(&norm_t).collect();
-        LNFact::fresh_annotated(f.tag.clone(), f.annotations.clone(), terms)
+        LNFact::fresh_annotated(f.tag, f.annotations.clone(), terms)
     };
     Rule {
         info: ru.info.clone(),
@@ -1688,7 +1688,7 @@ fn bp_variants_intruder(
         let mut out: Vec<LNSubstVFresh> = Vec::new();
         for s in substs {
             let mappings = s.to_list();
-            let doms: Vec<LVar> = mappings.iter().map(|(d, _)| d.clone()).collect();
+            let doms: Vec<LVar> = mappings.iter().map(|(d, _)| *d).collect();
             let mut rngs: Vec<LNTerm> = mappings.iter().map(|(_, t)| t.clone()).collect();
             // `sort rngs` — `Ord LNTerm`.
             rngs.sort();

--- a/crates/tamarin-theory/src/intruder_rules.rs
+++ b/crates/tamarin-theory/src/intruder_rules.rs
@@ -2260,7 +2260,7 @@ mod tests {
             tag: NameTag::Pub,
             id: NameId::new("b"),
         };
-        let pa: LNTerm = Term::Lit(Lit::Con(pub_a.clone()));
+        let pa: LNTerm = Term::Lit(Lit::Con(pub_a));
         let pb: LNTerm = Term::Lit(Lit::Con(pub_b));
         let lhs = senc(Term::Lit(Lit::Var(x)), pair(pa.clone(), pb));
         let rhs_st = StRhs {

--- a/crates/tamarin-theory/src/intruder_variants.rs
+++ b/crates/tamarin-theory/src/intruder_variants.rs
@@ -307,7 +307,7 @@ fn compute_new_vars(prems: &[LNFact], concs: &[LNFact]) -> Vec<tamarin_term::lte
     fn collect(t: &tamarin_term::lterm::LNTerm, out: &mut BTreeSet<LVar>) {
         match t {
             Term::Lit(Lit::Var(v)) => {
-                out.insert(v.clone());
+                out.insert(*v);
             }
             Term::Lit(_) => {}
             Term::App(_, args) => {

--- a/crates/tamarin-theory/src/predicate.rs
+++ b/crates/tamarin-theory/src/predicate.rs
@@ -111,7 +111,7 @@ mod tests {
     fn lookup_finds_match() {
         let f: LNFormula = ProtoFormula::ltrue();
         let p = Predicate::new("foo", f, vec![]);
-        let probe: Fact<LVar> = Fact::new(p.fact.tag.clone(), vec![]);
+        let probe: Fact<LVar> = Fact::new(p.fact.tag, vec![]);
         let preds = vec![p];
         assert!(lookup_predicate(&probe, &preds).is_some());
     }

--- a/crates/tamarin-theory/src/replay.rs
+++ b/crates/tamarin-theory/src/replay.rs
@@ -1534,7 +1534,7 @@ mod tests {
         let i = LVar::new("t", LSort::Node, 0);
         let tag = FactTag::Proto(Multiplicity::Linear, "Setup", 0);
         let fact = Fact::new(tag, Vec::new());
-        let goal = Goal::Action(i.clone(), fact);
+        let goal = Goal::Action(i, fact);
         let mut sys = System::empty();
         sys.goals_mut().push((goal.clone(), Default::default()));
         let spec = GoalSpec::Action {
@@ -1595,16 +1595,16 @@ mod tests {
         // Two goals with the same fact tag/arity but different
         // timepoints.
         let g1 = Goal::Action(
-            i1.clone(),
+            i1,
             Fact::new(
-                tag.clone(),
+                tag,
                 vec![tamarin_term::term::Term::Lit(
                     tamarin_term::vterm::Lit::Var(LVar::new("x", LSort::Msg, 0)),
                 )],
             ),
         );
         let g2 = Goal::Action(
-            i2.clone(),
+            i2,
             Fact::new(
                 tag,
                 vec![tamarin_term::term::Term::Lit(
@@ -1698,7 +1698,7 @@ mod tests {
         let n1 = LVar::new("u", LSort::Node, 0);
         let n2 = LVar::new("v", LSort::Node, 0);
         let tag = FactTag::Proto(Multiplicity::Linear, "Inp", 0);
-        let g1 = Goal::Premise((n1, PremIdx(0)), Fact::new(tag.clone(), Vec::new()));
+        let g1 = Goal::Premise((n1, PremIdx(0)), Fact::new(tag, Vec::new()));
         let g2 = Goal::Premise((n2, PremIdx(0)), Fact::new(tag, Vec::new()));
         let mut sys = System::empty();
         sys.goals_mut().push((g1, Default::default()));
@@ -1731,8 +1731,8 @@ mod tests {
         let i = LVar::new("i", LSort::Node, 3);
         let j = LVar::new("j", LSort::Node, 5);
         let k = LVar::new("k", LSort::Node, 7);
-        let g_ij = Goal::Chain((i.clone(), ConcIdx(0)), (j.clone(), PremIdx(2)));
-        let g_jk = Goal::Chain((j.clone(), ConcIdx(1)), (k.clone(), PremIdx(0)));
+        let g_ij = Goal::Chain((i, ConcIdx(0)), (j, PremIdx(2)));
+        let g_jk = Goal::Chain((j, ConcIdx(1)), (k, PremIdx(0)));
         let mut sys = System::empty();
         sys.goals_mut().push((g_ij.clone(), Default::default()));
         sys.goals_mut().push((g_jk.clone(), Default::default()));

--- a/crates/tamarin-theory/src/rule.rs
+++ b/crates/tamarin-theory/src/rule.rs
@@ -246,7 +246,7 @@ impl RuleAttributes {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum ProtoRuleName {
     /// The reserved `Fresh` rule.
     Fresh,

--- a/crates/tamarin-theory/src/sapic.rs
+++ b/crates/tamarin-theory/src/sapic.rs
@@ -465,7 +465,7 @@ mod tests {
     #[test]
     fn sapic_lvar_round_trip() {
         let v = LVar::new("x", LSort::Msg, 0);
-        let sv = SapicLVar::untyped(v.clone());
+        let sv = SapicLVar::untyped(v);
         assert_eq!(sv.to_lvar(), v);
     }
 

--- a/crates/tamarin-theory/src/sapic.rs
+++ b/crates/tamarin-theory/src/sapic.rs
@@ -100,7 +100,7 @@ impl SapicLVar {
         SapicLVar { var, stype: None }
     }
     pub fn to_lvar(&self) -> LVar {
-        self.var.clone()
+        self.var
     }
 }
 

--- a/crates/tamarin-theory/src/tools/equation_store.rs
+++ b/crates/tamarin-theory/src/tools/equation_store.rs
@@ -1631,10 +1631,7 @@ impl EquationStore {
                 v,
                 Term::App(
                     op,
-                    fvars
-                        .iter()
-                        .map(|fv| Term::Lit(Lit::Var(*fv)))
-                        .collect(),
+                    fvars.iter().map(|fv| Term::Lit(Lit::Var(*fv))).collect(),
                 ),
             )]);
             // Apply factor (via apply_eq_store if maude available).
@@ -1700,11 +1697,7 @@ impl EquationStore {
                 v,
                 Term::App(
                     op,
-                    vec![
-                        Term::Lit(Lit::Var(fv1)),
-                        Term::Lit(Lit::Var(fv2)),
-                    ]
-                    .into(),
+                    vec![Term::Lit(Lit::Var(fv1)), Term::Lit(Lit::Var(fv2))].into(),
                 ),
             )]);
             // HS-faithful order (`foreachDisj`): replace the disj FIRST,

--- a/crates/tamarin-theory/src/tools/equation_store.rs
+++ b/crates/tamarin-theory/src/tools/equation_store.rs
@@ -105,8 +105,8 @@ fn freshen_witness_range(
     // Apply the rename across each (var, term).  Keys get renamed too.
     raw.into_iter()
         .map(|(v, t)| {
-            let new_v = renames.get(&v).cloned().unwrap_or(v);
-            let new_t = t.map_free(&mut |w| renames.get(&w).cloned().unwrap_or(w));
+            let new_v = renames.get(&v).copied().unwrap_or(v);
+            let new_t = t.map_free(&mut |w| renames.get(&w).copied().unwrap_or(w));
             (new_v, new_t)
         })
         .collect()
@@ -986,7 +986,7 @@ impl EquationStore {
     ) -> Result<SplitId, &'static str> {
         // Domain-disjointness check: free-subst domain must not
         // overlap with any variant's domain.
-        let free_dom: BTreeSet<LVar> = self.subst.dom().cloned().collect();
+        let free_dom: BTreeSet<LVar> = self.subst.dom().copied().collect();
         for v in &variants {
             if v.dom().any(|x| free_dom.contains(x)) {
                 return Err("addRuleVariants: nonempty intersection between domain \
@@ -2665,9 +2665,9 @@ impl EquationStore {
                         }
                     }
                     let witness_map: std::collections::BTreeMap<LVar, LVar> =
-                        witnesses.iter().cloned().collect();
+                        witnesses.iter().copied().collect();
                     let rename_term = |t: LNTerm| -> LNTerm {
-                        t.map_free(&mut |v: LVar| witness_map.get(&v).cloned().unwrap_or(v))
+                        t.map_free(&mut |v: LVar| witness_map.get(&v).copied().unwrap_or(v))
                     };
                     // Build lifted subst: rename range values, add
                     // S → Var(W) entries to domain.
@@ -3344,13 +3344,13 @@ mod tests {
                 }],
             )
             .expect("first add_eqs");
-        let dom_before: Vec<LVar> = store.subst.dom().cloned().collect();
+        let dom_before: Vec<LVar> = store.subst.dom().copied().collect();
 
         // Repeat — should be a no-op.
         let _ = store
             .add_eqs(&h, &[tamarin_term::rewriting::Equal { lhs: tx, rhs: ty }])
             .expect("second add_eqs");
-        let dom_after: Vec<LVar> = store.subst.dom().cloned().collect();
+        let dom_after: Vec<LVar> = store.subst.dom().copied().collect();
         assert_eq!(
             dom_before, dom_after,
             "Repeated add_eqs of an already-implied equation must \

--- a/crates/tamarin-theory/src/tools/equation_store.rs
+++ b/crates/tamarin-theory/src/tools/equation_store.rs
@@ -3108,8 +3108,8 @@ mod tests {
         use tamarin_term::vterm::Lit;
         let v = LVar::new("x", LSort::Msg, 0);
         let foo: LNTerm = Term::Lit(Lit::Con(Name::new(NameTag::Pub, "foo".to_string())));
-        let s1 = LNSubstVFresh::from_list(vec![(v.clone(), foo.clone())]);
-        let s2 = LNSubstVFresh::from_list(vec![(v.clone(), foo.clone())]);
+        let s1 = LNSubstVFresh::from_list(vec![(v, foo.clone())]);
+        let s2 = LNSubstVFresh::from_list(vec![(v, foo.clone())]);
         let mut store = EquationStore::empty();
         let _ = store.add_disj(vec![s1, s2]);
         assert!(store.simp_abstract_name());
@@ -3222,8 +3222,8 @@ mod tests {
         let e10 = LVar::new("e", LSort::Msg, 10);
         use tamarin_term::term::Term;
         use tamarin_term::vterm::Lit;
-        let lt1: LNTerm = Term::Lit(Lit::Var(t1.clone()));
-        let le10: LNTerm = Term::Lit(Lit::Var(e10.clone()));
+        let lt1: LNTerm = Term::Lit(Lit::Var(t1));
+        let le10: LNTerm = Term::Lit(Lit::Var(e10));
 
         let mut store = EquationStore::empty();
         let split = store
@@ -3276,8 +3276,8 @@ mod tests {
         let y = LVar::new("y", LSort::Msg, 0);
         use tamarin_term::term::Term;
         use tamarin_term::vterm::Lit;
-        let tx: LNTerm = Term::Lit(Lit::Var(x.clone()));
-        let ty: LNTerm = Term::Lit(Lit::Var(y.clone()));
+        let tx: LNTerm = Term::Lit(Lit::Var(x));
+        let ty: LNTerm = Term::Lit(Lit::Var(y));
         let mut store = EquationStore::empty();
         let _ = store
             .add_eqs(&h, &[tamarin_term::rewriting::Equal { lhs: tx, rhs: ty }])
@@ -3332,8 +3332,8 @@ mod tests {
         let y = LVar::new("y", LSort::Msg, 5);
         use tamarin_term::term::Term;
         use tamarin_term::vterm::Lit;
-        let tx: LNTerm = Term::Lit(Lit::Var(x.clone()));
-        let ty: LNTerm = Term::Lit(Lit::Var(y.clone()));
+        let tx: LNTerm = Term::Lit(Lit::Var(x));
+        let ty: LNTerm = Term::Lit(Lit::Var(y));
         let mut store = EquationStore::empty();
         let _ = store
             .add_eqs(

--- a/crates/tamarin-theory/src/tools/equation_store.rs
+++ b/crates/tamarin-theory/src/tools/equation_store.rs
@@ -72,7 +72,7 @@ fn freshen_witness_range(
     use std::collections::BTreeMap;
     use tamarin_term::lterm::HasFrees;
     let trace = tamarin_utils::env_gate!("TAM_DBG_FRESHEN_WITNESS");
-    let domain: BTreeSet<LVar> = raw.iter().map(|(v, _)| v.clone()).collect();
+    let domain: BTreeSet<LVar> = raw.iter().map(|(v, _)| *v).collect();
     // Witnesses = range-only vars that are neither a domain key nor an
     // input var (i.e. auxiliaries the Maude unifier introduced); these are
     // the ones that need a globally-unique idx.
@@ -85,7 +85,7 @@ fn freshen_witness_range(
             if input_vars.contains(w) {
                 return;
             }
-            witnesses.insert(w.clone());
+            witnesses.insert(*w);
         });
     }
     if witnesses.is_empty() {
@@ -97,7 +97,7 @@ fn freshen_witness_range(
     let mut renames: BTreeMap<LVar, LVar> = BTreeMap::new();
     for v in witnesses {
         let next = maude.fresh_idx();
-        renames.insert(v.clone(), LVar { idx: next, ..v });
+        renames.insert(v, LVar { idx: next, ..v });
     }
     if trace && !renames.is_empty() {
         eprintln!("[freshen_witness] {} witness renames", renames.len());
@@ -413,7 +413,7 @@ impl EquationStore {
                                 break;
                             }
                         }
-                        seen.insert(v_str, (k.clone(), vv.clone()));
+                        seen.insert(v_str, (*k, *vv));
                     }
                 }
                 if found_bad {
@@ -849,10 +849,10 @@ impl EquationStore {
                 std::collections::BTreeSet::new();
             for e in &ac_residuals {
                 e.lhs.for_each_free(&mut |v| {
-                    input_vars.insert(v.clone());
+                    input_vars.insert(*v);
                 });
                 e.rhs.for_each_free(&mut |v| {
-                    input_vars.insert(v.clone());
+                    input_vars.insert(*v);
                 });
             }
             let raw = freshen_witness_range(
@@ -1228,7 +1228,7 @@ impl EquationStore {
                     .iter()
                     .all(|s| s.image_of(v).map(|got| got == t).unwrap_or(false));
                 if common {
-                    common_mapping = Some((v.clone(), t.clone(), idx));
+                    common_mapping = Some((*v, t.clone(), idx));
                     break;
                 }
             }
@@ -1242,7 +1242,7 @@ impl EquationStore {
         };
         // Compose `{v → t}` into the free substitution and drop `v`
         // from every subst in disjunction `idx`.
-        let factor = LNSubst::from_list(vec![(v.clone(), t)]);
+        let factor = LNSubst::from_list(vec![(v, t)]);
         // HS-faithful order (`foreachDisj`, EquationStore.hs):
         // REPLACE the disj FIRST, THEN applyEqStore.  (For simpAbstractName
         // the factor's range is a constant; we follow the HS replace-then-
@@ -1349,7 +1349,7 @@ impl EquationStore {
                 for (i, (v, t)) in entries.iter().enumerate() {
                     for (v2, t2) in entries.iter().skip(i + 1) {
                         if t == t2 && v < v2 {
-                            out.push(((*v).clone(), (*v2).clone()));
+                            out.push((*(*v), *(*v2)));
                         }
                     }
                 }
@@ -1362,7 +1362,7 @@ impl EquationStore {
                     i1.is_some() && i1 == i2
                 });
                 if agrees {
-                    to_apply = Some((v.clone(), v2.clone(), idx));
+                    to_apply = Some((*v, *v2, idx));
                     break;
                 }
             }
@@ -1377,13 +1377,13 @@ impl EquationStore {
         // Decide which to keep: the variable with the larger sort
         // (Tamarin says "GT means keep first"; we use the same rule).
         let (keep, remove) = match sort_compare(v.sort, v2.sort) {
-            Some(std::cmp::Ordering::Greater) => (v2.clone(), v.clone()),
-            Some(_) => (v.clone(), v2.clone()),
+            Some(std::cmp::Ordering::Greater) => (v2, v),
+            Some(_) => (v, v2),
             None => return false, // incomparable sorts; bail
         };
         let factor = LNSubst::from_list(vec![(
-            remove.clone(),
-            tamarin_term::term::Term::Lit(tamarin_term::vterm::Lit::Var(keep.clone())),
+            remove,
+            tamarin_term::term::Term::Lit(tamarin_term::vterm::Lit::Var(keep)),
         )]);
         // HS-faithful: apply factor via apply_eq_store (re-unifies
         // variants against new free subst).  Falls back to compose if
@@ -1460,7 +1460,7 @@ impl EquationStore {
             // Borrowing scan — entries are cloned only on match.
             for (v, t) in first.iter() {
                 let lx = match t {
-                    Term::Lit(Lit::Var(lx)) => lx.clone(),
+                    Term::Lit(Lit::Var(lx)) => *lx,
                     _ => continue,
                 };
                 if !matches!(
@@ -1469,12 +1469,12 @@ impl EquationStore {
                 ) {
                     continue;
                 }
-                let mut lvs: Vec<LVar> = vec![lx.clone()];
+                let mut lvs: Vec<LVar> = vec![lx];
                 let mut all_match = true;
                 for other in d.substs.iter().skip(1) {
                     match other.image_of(v) {
                         Some(Term::Lit(Lit::Var(ly))) if ly.sort == lx.sort => {
-                            lvs.push(ly.clone());
+                            lvs.push(*ly);
                         }
                         _ => {
                             all_match = false;
@@ -1483,7 +1483,7 @@ impl EquationStore {
                     }
                 }
                 if all_match {
-                    to_apply = Some((v.clone(), lx.sort, lvs, idx));
+                    to_apply = Some((*v, lx.sort, lvs, idx));
                     break;
                 }
             }
@@ -1509,7 +1509,7 @@ impl EquationStore {
             );
         }
         // Compose {v → Var(fv)} into the free substitution.
-        let factor = LNSubst::from_list(vec![(v.clone(), Term::Lit(Lit::Var(fv.clone())))]);
+        let factor = LNSubst::from_list(vec![(v, Term::Lit(Lit::Var(fv)))]);
         // HS-faithful: foreachDisj (EquationStore.hs) REPLACES
         // the disj with the abstracted substs FIRST, THEN calls
         // `applyEqStore hnd msubst`.  Apply the abstraction to the disj
@@ -1523,7 +1523,7 @@ impl EquationStore {
             .zip(lvs.iter())
             .map(|(s, lv)| {
                 let mut kept = without_key(s, &v);
-                kept.push((fv.clone(), Term::Lit(Lit::Var(lv.clone()))));
+                kept.push((fv, Term::Lit(Lit::Var(*lv))));
                 LNSubstVFresh::from_list(kept)
             })
             .collect();
@@ -1587,7 +1587,7 @@ impl EquationStore {
                     }
                 }
                 if ok {
-                    to_apply = Some((idx, v.clone(), op, argss));
+                    to_apply = Some((idx, *v, op, argss));
                     break 'outer;
                 }
             }
@@ -1628,12 +1628,12 @@ impl EquationStore {
             }
             // Build factor `{v → op(x1, ..., xk)}`.
             let factor = LNSubst::from_list(vec![(
-                v.clone(),
+                v,
                 Term::App(
                     op,
                     fvars
                         .iter()
-                        .map(|fv| Term::Lit(Lit::Var(fv.clone())))
+                        .map(|fv| Term::Lit(Lit::Var(*fv)))
                         .collect(),
                 ),
             )]);
@@ -1669,7 +1669,7 @@ impl EquationStore {
                 .map(|(s, args)| {
                     let mut kept = without_key(s, &v);
                     for (fv, a) in fvars.iter().zip(args.iter()) {
-                        kept.push((fv.clone(), a.clone()));
+                        kept.push((*fv, a.clone()));
                     }
                     LNSubstVFresh::from_list(kept)
                 })
@@ -1697,12 +1697,12 @@ impl EquationStore {
             }
             // Factor: `{v → op(fv1, fv2)}`
             let factor = LNSubst::from_list(vec![(
-                v.clone(),
+                v,
                 Term::App(
                     op,
                     vec![
-                        Term::Lit(Lit::Var(fv1.clone())),
-                        Term::Lit(Lit::Var(fv2.clone())),
+                        Term::Lit(Lit::Var(fv1)),
+                        Term::Lit(Lit::Var(fv2)),
                     ]
                     .into(),
                 ),
@@ -1734,8 +1734,8 @@ impl EquationStore {
                         // `newMappings (a:as) = [(fv1,a),(fv2,fApp o as)]`
                         [a1, rest @ ..] => (a1.clone(), Term::App(op, rest.to_vec().into())),
                     };
-                    kept.push((fv1.clone(), a1));
-                    kept.push((fv2.clone(), a_rest));
+                    kept.push((fv1, a1));
+                    kept.push((fv2, a_rest));
                     LNSubstVFresh::from_list(kept)
                 })
                 .collect();
@@ -2288,7 +2288,7 @@ impl EquationStore {
                         new_subst_range_max = v.idx;
                     }
                     if !new_subst_range_vars.contains(v) {
-                        new_subst_range_vars.insert(v.clone());
+                        new_subst_range_vars.insert(*v);
                     }
                 });
             }
@@ -2422,7 +2422,7 @@ impl EquationStore {
                     .iter()
                     .zip(renamed_rhs)
                     .map(|(&(lv, _), t)| {
-                        let lv_t = Term::Lit(Lit::Var(lv.clone()));
+                        let lv_t = Term::Lit(Lit::Var(*lv));
                         Equal {
                             lhs: tamarin_term::subst::apply_vterm(&new_subst, lv_t),
                             rhs: t,
@@ -2561,7 +2561,7 @@ impl EquationStore {
                 // witness and renames it, breaking the binding to the
                 // rule's premise (Client_auth Ltk vs In ltkS desync).
                 let orig_dom: tamarin_utils::FastSet<LVar> =
-                    bindings.iter().map(|&(k, _)| k.clone()).collect();
+                    bindings.iter().map(|&(k, _)| *k).collect();
                 for raw in unifiers {
                     // TAM_DBG_RAW_UNIFIER=1: dump Maude's raw output.
                     if aes_dbg_raw_unifier() {
@@ -2624,7 +2624,7 @@ impl EquationStore {
                     // `to_lift` carries the byte-visible order), so hash
                     // sets replace the per-unifier BTreeSet builds.
                     let current_dom: tamarin_utils::FastSet<LVar> =
-                        raw.iter().map(|(k, _)| k.clone()).collect();
+                        raw.iter().map(|(k, _)| *k).collect();
                     // `orig_dom` (this variant's ORIGINAL bindings.keys —
                     // the variant's system vars from its domain) is hoisted
                     // above the unifier loop; it participates in the
@@ -2638,8 +2638,8 @@ impl EquationStore {
                         t.for_each_free(&mut |v: &LVar| {
                             let is_system =
                                 new_subst_range_vars.contains(v) || orig_dom.contains(v);
-                            if is_system && !current_dom.contains(v) && seen.insert(v.clone()) {
-                                to_lift.push(v.clone());
+                            if is_system && !current_dom.contains(v) && seen.insert(*v) {
+                                to_lift.push(*v);
                             }
                         });
                     }
@@ -2668,7 +2668,7 @@ impl EquationStore {
                                 sort: s.sort,
                                 idx: base + i as u64,
                             };
-                            witnesses.push((s.clone(), w));
+                            witnesses.push((*s, w));
                         }
                     }
                     let witness_map: std::collections::BTreeMap<LVar, LVar> =
@@ -2812,7 +2812,7 @@ impl EquationStore {
                                     break;
                                 }
                             }
-                            seen.insert(v_str, k.clone());
+                            seen.insert(v_str, *k);
                         }
                     }
                 }

--- a/crates/tamarin-theory/src/tools/injective_fact_instances.rs
+++ b/crates/tamarin-theory/src/tools/injective_fact_instances.rs
@@ -569,7 +569,7 @@ mod tests {
         use tamarin_term::builtin::msg_var;
 
         let a_tag = FactTag::Proto(Multiplicity::Linear, "A", 1);
-        let a_fact = Fact::new(a_tag.clone(), vec![msg_var("x", 0)]);
+        let a_fact = Fact::new(a_tag, vec![msg_var("x", 0)]);
         let start: ProtoRuleE = Rule::new(
             ProtoRuleEInfo::standard("Start"),
             vec![fresh_fact(msg_var("x", 0))],
@@ -604,7 +604,7 @@ mod tests {
         use tamarin_term::builtin::msg_var;
 
         let s_tag = FactTag::Proto(Multiplicity::Linear, "S", 2);
-        let s_fact = Fact::new(s_tag.clone(), vec![msg_var("id", 0), msg_var("k", 0)]);
+        let s_fact = Fact::new(s_tag, vec![msg_var("id", 0), msg_var("k", 0)]);
         let init: ProtoRuleE = Rule::new(
             ProtoRuleEInfo::standard("Init"),
             vec![fresh_fact(msg_var("id", 0))],
@@ -636,7 +636,7 @@ mod tests {
         use tamarin_term::builtin::msg_var;
 
         let b_tag = FactTag::Proto(Multiplicity::Linear, "B", 1);
-        let b_fact = Fact::new(b_tag.clone(), vec![msg_var("y", 0)]);
+        let b_fact = Fact::new(b_tag, vec![msg_var("y", 0)]);
         // No Fresh premise binding `y`, no `B` premise.
         let weird: ProtoRuleE = Rule::new(
             ProtoRuleEInfo::standard("Weird"),
@@ -661,18 +661,18 @@ mod tests {
 
         let s_tag = FactTag::Proto(Multiplicity::Linear, "S", 2);
         let prem_fact = Fact::new(
-            s_tag.clone(),
+            s_tag,
             vec![msg_var("id", 0), pair(msg_var("a", 0), msg_var("b", 0))],
         );
         let conc_fact = Fact::new(
-            s_tag.clone(),
+            s_tag,
             vec![msg_var("id", 0), pair(msg_var("a", 0), msg_var("c", 0))],
         );
         let init: ProtoRuleE = Rule::new(
             ProtoRuleEInfo::standard("Init"),
             vec![fresh_fact(msg_var("id", 0))],
             vec![Fact::new(
-                s_tag.clone(),
+                s_tag,
                 vec![msg_var("id", 0), pair(msg_var("a", 0), msg_var("b", 0))],
             )],
             vec![],
@@ -708,7 +708,7 @@ mod tests {
         use tamarin_term::builtin::msg_var;
 
         let a_tag = FactTag::Proto(Multiplicity::Linear, "A", 1);
-        let a_fact = Fact::new(a_tag.clone(), vec![msg_var("x", 0)]);
+        let a_fact = Fact::new(a_tag, vec![msg_var("x", 0)]);
         let r: ProtoRuleE = Rule::new(
             ProtoRuleEInfo::standard("Dup"),
             vec![a_fact.clone()],
@@ -756,7 +756,7 @@ mod tests {
         use tamarin_term::builtin::msg_var;
 
         let st_tag = FactTag::Proto(Multiplicity::Linear, "St", 2);
-        let st_fact = Fact::new(st_tag.clone(), vec![msg_var("x", 0), msg_var("k", 0)]);
+        let st_fact = Fact::new(st_tag, vec![msg_var("x", 0), msg_var("k", 0)]);
         // Step1 creates St but doesn't consume it.
         let step1: ProtoRuleE = Rule::new(
             ProtoRuleEInfo::standard("Step1"),
@@ -794,7 +794,7 @@ mod tests {
         use tamarin_term::builtin::msg_var;
 
         let p_tag = FactTag::Proto(Multiplicity::Persistent, "P", 1);
-        let p_fact = Fact::new(p_tag.clone(), vec![msg_var("x", 0)]);
+        let p_fact = Fact::new(p_tag, vec![msg_var("x", 0)]);
         // Even with both prems + concs (which would normally pass the
         // candidate filter), Persistent disqualifies.
         let r: ProtoRuleE = Rule::new(
@@ -822,7 +822,7 @@ mod tests {
         use crate::rule::{ProtoRuleEInfo, Rule};
 
         let z_tag = FactTag::Proto(Multiplicity::Linear, "Z", 0);
-        let z_fact = Fact::new(z_tag.clone(), vec![]);
+        let z_fact = Fact::new(z_tag, vec![]);
         let r: ProtoRuleE = Rule::new(
             ProtoRuleEInfo::standard("R"),
             vec![z_fact.clone()],

--- a/crates/tamarin-theory/src/tools/injective_fact_instances.rs
+++ b/crates/tamarin-theory/src/tools/injective_fact_instances.rs
@@ -331,8 +331,8 @@ pub fn simple_injective_fact_instances(
         use tamarin_term::term::Term;
         use tamarin_term::vterm::Lit;
         match t {
-            Term::Lit(Lit::Con(n)) => Some(Term::Lit(Lit::Con(n.clone()))),
-            Term::Lit(Lit::Var(BVar::Free(v))) => Some(Term::Lit(Lit::Var(v.clone()))),
+            Term::Lit(Lit::Con(n)) => Some(Term::Lit(Lit::Con(*n))),
+            Term::Lit(Lit::Var(BVar::Free(v))) => Some(Term::Lit(Lit::Var(*v))),
             Term::Lit(Lit::Var(BVar::Bound(_))) => None,
             Term::App(sym, args) => {
                 let mapped: Option<Vec<LNTerm>> = args.iter().map(bvar_term_to_lnterm).collect();
@@ -364,7 +364,7 @@ pub fn simple_injective_fact_instances(
     let mut candidates: BTreeMap<FactTag, Vec<Vec<MonotonicBehaviour>>> = BTreeMap::new();
     for &r in rules {
         let prem_tags: std::collections::BTreeSet<FactTag> =
-            r.premises.iter().map(|p| p.tag.clone()).collect();
+            r.premises.iter().map(|p| p.tag).collect();
         for conc in &r.conclusions {
             let tag = &conc.tag;
             if !matches!(tag, FactTag::Proto(_, _, _)) {
@@ -382,7 +382,7 @@ pub fn simple_injective_fact_instances(
                 }
                 let shape = combine_shapes(&get_shape(conc), &get_shape(prem));
                 candidates
-                    .entry(tag.clone())
+                    .entry(*tag)
                     .and_modify(|existing| *existing = combine_shapes(existing, &shape))
                     .or_insert(shape);
             }
@@ -494,7 +494,7 @@ pub fn simple_injective_fact_instances(
             .iter()
             .map(|&r| get_maybe_eq_strict(tag, r, default_shape));
         if let Some(behaviours) = combine_all(per_rule, default_shape) {
-            out.push((tag.clone(), behaviours));
+            out.push((*tag, behaviours));
         }
     }
     out
@@ -536,7 +536,7 @@ pub fn union_forced_injective_fact_instances(
         // `S.union` is LEFT-biased; the forced entry wins on collision.
         let arity = fact_tag_arity(tag);
         let behaviour = vec![vec![MonotonicBehaviour::Unspecified]; arity];
-        map.insert(tag.clone(), behaviour);
+        map.insert(*tag, behaviour);
     }
     map.into_iter().collect()
 }

--- a/crates/tamarin-theory/src/tools/injective_fact_instances.rs
+++ b/crates/tamarin-theory/src/tools/injective_fact_instances.rs
@@ -170,7 +170,7 @@ pub fn trimmed_pair_terms(
         .zip(behaviours.iter())
         .flat_map(|(term, behaviour)| {
             let leaves = shape_term(term, behaviour.len());
-            behaviour.iter().cloned().zip(leaves).collect::<Vec<_>>()
+            behaviour.iter().copied().zip(leaves).collect::<Vec<_>>()
         })
         .collect();
     Some((first, pairs))

--- a/crates/tamarin-theory/src/tools/rule_variants.rs
+++ b/crates/tamarin-theory/src/tools/rule_variants.rs
@@ -202,27 +202,27 @@ fn make_proto_rule_ac(
     for f in &premises {
         for t in f.terms.iter() {
             t.for_each_free(&mut |v| {
-                frees_set.insert(v.clone());
+                frees_set.insert(*v);
             });
         }
     }
     for f in &conclusions {
         for t in f.terms.iter() {
             t.for_each_free(&mut |v| {
-                frees_set.insert(v.clone());
+                frees_set.insert(*v);
             });
         }
     }
     for f in &actions {
         for t in f.terms.iter() {
             t.for_each_free(&mut |v| {
-                frees_set.insert(v.clone());
+                frees_set.insert(*v);
             });
         }
     }
     for t in &new_vars {
         t.for_each_free(&mut |v| {
-            frees_set.insert(v.clone());
+            frees_set.insert(*v);
         });
     }
     let frees_vec: Vec<LVar> = frees_set.into_iter().collect();
@@ -232,7 +232,7 @@ fn make_proto_rule_ac(
         .collect();
 
     let info = ProtoRuleACInfo {
-        name: rule.info.name.clone(),
+        name: rule.info.name,
         attributes: rule.info.attributes.clone(),
         variants,
         loop_breakers: Vec::new(),
@@ -445,7 +445,7 @@ pub fn abstract_rule_and_variants(
         // Catch-all: import binding (handles leaf vars AND reducible-head
         // App).  HS: `abstrTerm t = do at <- varTerm <$> importBinding ...`.
         if let Some(v) = bindings.get(t) {
-            return Term::Lit(tamarin_term::vterm::Lit::Var(v.clone()));
+            return Term::Lit(tamarin_term::vterm::Lit::Var(*v));
         }
         let new_idx = maude.reserve_idxs(1);
         let v = LVar {
@@ -458,7 +458,7 @@ pub fn abstract_rule_and_variants(
             sort: tamarin_term::lterm::sort_of_lnterm(t),
             idx: new_idx,
         };
-        bindings.insert(t.clone(), v.clone());
+        bindings.insert(t.clone(), v);
         Term::Lit(tamarin_term::vterm::Lit::Var(v))
     }
 
@@ -474,7 +474,7 @@ pub fn abstract_rule_and_variants(
             .iter()
             .map(|t| abstr_term(t, irreducible, bindings, maude))
             .collect();
-        Fact::fresh_annotated(f.tag.clone(), f.annotations.clone(), terms)
+        Fact::fresh_annotated(f.tag, f.annotations.clone(), terms)
     }
 
     // HS-faithful: import ALL leaf vars FIRST (RuleVariants.hs:61-134, see line 95
@@ -506,7 +506,7 @@ pub fn abstract_rule_and_variants(
     // and dedupes — exactly `sortednub` semantics.
     let mut leaf_set: std::collections::BTreeSet<LVar> = std::collections::BTreeSet::new();
     let mut visit = |v: &LVar| {
-        leaf_set.insert(v.clone());
+        leaf_set.insert(*v);
     };
     for f in &rule.premises {
         f.terms.iter().for_each(|t| t.for_each_free(&mut visit));
@@ -608,7 +608,7 @@ pub fn abstract_rule_and_variants(
     // order — exactly `M.toList`'s ordering, no explicit sort needed.
     let abstraction_pairs: Vec<(LVar, LNTerm)> = bindings
         .iter()
-        .map(|(t, v)| (v.clone(), t.clone()))
+        .map(|(t, v)| (*v, t.clone()))
         .collect();
     let abstraction_subst: LNSubst = Subst::from_list(abstraction_pairs);
 
@@ -656,27 +656,27 @@ pub fn abstract_rule_and_variants(
         for f in &abstracted_rule.premises {
             for t in f.terms.iter() {
                 t.for_each_free(&mut |v| {
-                    s.insert(v.clone());
+                    s.insert(*v);
                 });
             }
         }
         for f in &abstracted_rule.actions {
             for t in f.terms.iter() {
                 t.for_each_free(&mut |v| {
-                    s.insert(v.clone());
+                    s.insert(*v);
                 });
             }
         }
         for f in &abstracted_rule.conclusions {
             for t in f.terms.iter() {
                 t.for_each_free(&mut |v| {
-                    s.insert(v.clone());
+                    s.insert(*v);
                 });
             }
         }
         for t in &abstracted_rule.new_vars {
             t.for_each_free(&mut |v| {
-                s.insert(v.clone());
+                s.insert(*v);
             });
         }
         s.into_iter().collect()
@@ -715,7 +715,7 @@ pub fn abstract_rule_and_variants(
             let mut frees = std::collections::BTreeSet::new();
             for t in &premise_terms_for_filter {
                 t.for_each_free(&mut |v| {
-                    frees.insert(v.clone());
+                    frees.insert(*v);
                 });
             }
             // HS-faithful: `freshToFreeAvoidingFast sFresh (frees premiseTerms)`
@@ -968,7 +968,7 @@ fn rule_renames_under_precise(rule: &ProtoRuleE) -> bool {
     use tamarin_utils::fresh::PreciseFreshState;
     let mut vars: Vec<LVar> = Vec::new();
     {
-        let mut collect = |v: &LVar| vars.push(v.clone());
+        let mut collect = |v: &LVar| vars.push(*v);
         for f in &rule.premises {
             for t in f.terms.iter() {
                 t.for_each_free(&mut collect);
@@ -999,7 +999,7 @@ fn rule_renames_under_precise(rule: &ProtoRuleE) -> bool {
             return true;
         }
         map.insert(
-            v.clone(),
+            *v,
             LVar {
                 name: v.name,
                 sort: v.sort,
@@ -1059,7 +1059,7 @@ fn rename_precise_rule_with_variants(
             sort: v.sort,
             idx,
         };
-        m.insert(v.clone(), new_v);
+        m.insert(*v, new_v);
     };
 
     // Phase 1: walk every free LVar in HS's `mapFrees (Rule ProtoRuleACInfo)`
@@ -1099,7 +1099,7 @@ fn rename_precise_rule_with_variants(
     }
 
     // Phase 2: apply the renaming map.
-    let map_var = |v: &LVar| -> LVar { map.get(v).cloned().unwrap_or_else(|| v.clone()) };
+    let map_var = |v: &LVar| -> LVar { map.get(v).cloned().unwrap_or(*v) };
     let map_term = |t: LNTerm| -> LNTerm { t.map_free(&mut |v| map_var(&v)) };
     let map_facts = |fs: Vec<Fact<LNTerm>>| -> Vec<Fact<LNTerm>> {
         fs.into_iter()

--- a/crates/tamarin-theory/src/tools/rule_variants.rs
+++ b/crates/tamarin-theory/src/tools/rule_variants.rs
@@ -1097,7 +1097,7 @@ fn rename_precise_rule_with_variants(
     }
 
     // Phase 2: apply the renaming map.
-    let map_var = |v: &LVar| -> LVar { map.get(v).cloned().unwrap_or(*v) };
+    let map_var = |v: &LVar| -> LVar { map.get(v).copied().unwrap_or(*v) };
     let map_term = |t: LNTerm| -> LNTerm { t.map_free(&mut |v| map_var(&v)) };
     let map_facts = |fs: Vec<Fact<LNTerm>>| -> Vec<Fact<LNTerm>> {
         fs.into_iter()

--- a/crates/tamarin-theory/src/tools/rule_variants.rs
+++ b/crates/tamarin-theory/src/tools/rule_variants.rs
@@ -606,10 +606,8 @@ pub fn abstract_rule_and_variants(
     // ordered query payload) read from this sorted view.  `bindings` is a
     // `BTreeMap`, so `.iter()` already yields entries in term-`Ord` key
     // order — exactly `M.toList`'s ordering, no explicit sort needed.
-    let abstraction_pairs: Vec<(LVar, LNTerm)> = bindings
-        .iter()
-        .map(|(t, v)| (*v, t.clone()))
-        .collect();
+    let abstraction_pairs: Vec<(LVar, LNTerm)> =
+        bindings.iter().map(|(t, v)| (*v, t.clone())).collect();
     let abstraction_subst: LNSubst = Subst::from_list(abstraction_pairs);
 
     // `abstractedTerms = map snd eqsAbstr` — the ORIGINAL terms.

--- a/crates/tamarin-theory/src/tools/subterm_store.rs
+++ b/crates/tamarin-theory/src/tools/subterm_store.rs
@@ -239,7 +239,7 @@ pub fn collect_fresh_vars_not_below_reducible(
             }
         }
         Term::Lit(Lit::Var(v)) if v.sort == LSort::Fresh => {
-            out.insert(v.clone());
+            out.insert(*v);
         }
         _ => {}
     }

--- a/crates/tamarin-theory/tests/oracle_solver.rs
+++ b/crates/tamarin-theory/tests/oracle_solver.rs
@@ -1588,7 +1588,7 @@ fn probe_nspk3_cyclic_leaf() {
             for prem in &ru.premises {
                 if matches!(prem.tag, tamarin_theory::fact::FactTag::Fresh) {
                     let mut vars = Vec::new();
-                    prem.for_each_free(&mut |v| vars.push(v.clone()));
+                    prem.for_each_free(&mut |v| vars.push(*v));
                     if let Some(v) = vars
                         .into_iter()
                         .find(|v| v.sort == tamarin_term::lterm::LSort::Fresh)
@@ -1597,7 +1597,7 @@ fn probe_nspk3_cyclic_leaf() {
                             .chars()
                             .take(60)
                             .collect::<String>();
-                        fresh_consumers.push((id.clone(), v, info));
+                        fresh_consumers.push((*id, v, info));
                     }
                 }
             }

--- a/crates/tamarin-utils/src/dag.rs
+++ b/crates/tamarin-utils/src/dag.rs
@@ -356,7 +356,7 @@ mod tests {
         // 1 -> 2 -> 3, plus shortcut 1 -> 3
         let r = rel(&[(1, 2), (2, 3), (1, 3)]);
         let red = trans_red(&r);
-        let red_set: BTreeSet<(i32, i32)> = red.iter().cloned().collect();
+        let red_set: BTreeSet<(i32, i32)> = red.iter().copied().collect();
         // The reduction must drop (1,3) and keep (1,2),(2,3).
         assert!(red_set.contains(&(1, 2)));
         assert!(red_set.contains(&(2, 3)));

--- a/crates/tamarin-utils/src/misc.rs
+++ b/crates/tamarin-utils/src/misc.rs
@@ -397,7 +397,7 @@ mod tests {
         // There are 2^(n-1) results (the first list is never empty); here just
         // check that each pair covers the input.
         for (a, b) in &tp {
-            let mut combined: Vec<i32> = a.iter().chain(b.iter()).cloned().collect();
+            let mut combined: Vec<i32> = a.iter().chain(b.iter()).copied().collect();
             combined.sort();
             assert_eq!(combined, vec![1, 2, 3]);
         }


### PR DESCRIPTION
More `Copy` derives for types like `LVar`, `Quant` etc. followed by some clippy and fmt.

@kmilner I locally ran the `rs_vs_rs_diff.sh` script, but it only seemed to report timeouts for me. Assuming that `main` is always identical to the Haskell, we can setup a hook that runs the script against incoming PRs (on a subset of the models) to easily check them.