### PR TITLE
Deduplicate cleanup logic used in exec_proof_method

### DIFF
--- a/crates/tamarin-theory/src/constraint/solver/proof_method.rs
+++ b/crates/tamarin-theory/src/constraint/solver/proof_method.rs
@@ -427,7 +427,6 @@ pub fn exec_proof_method(
                 };
             }
             simp_noop_stat(false);
-
             // HS-faithful filter: cases whose eq_store is false were
             // mzero'd by `contradictoryIf` during simplify; they don't
             // show up in HS's surviving Disj.  (Other contradiction
@@ -729,11 +728,6 @@ pub fn exec_proof_method(
             // execs Induction while the batch search does not).
             // Route through `simplify_system_with_fanout` exactly like the
             // `Simplify` and `SolveGoal` arms.
-            let cleanup = |s: &mut System| {
-                crate::constraint::solver::rename_precise::rename_precise_system(s);
-                s.invalidate_max_var_idx_cache();
-                s.eq_store_mut().subst = tamarin_term::subst::Subst::from_list(Vec::new());
-            };
             // HS branch order: `disjunctionOfList [("empty_trace", base),
             // ("non_empty_trace", step)]` — base first, then step; each
             // branch's simplify sub-branches keep DisjT order (the same
@@ -750,7 +744,7 @@ pub fn exec_proof_method(
                 case_sys.formulas_mut().push(std::sync::Arc::new(fm_case));
                 let sub_systems: Vec<System> =
                     crate::constraint::solver::simplify::simplify_system_with_fanout(ctx, case_sys);
-                for mut s in sub_systems {
+                for s in sub_systems {
                     // mzero'd branches (eq-store false) don't survive HS's
                     // Disj — same filter as the Simplify/SolveGoal arms.
                     if s.eq_store.is_false() {
@@ -761,8 +755,7 @@ pub fn exec_proof_method(
                     // subst.  Without it the IH disjunction's free vars
                     // keep their high `.N` indices (e.g. `last(#z.7)`)
                     // instead of the canonical idx-0 form (`last(#z)`).
-                    cleanup(&mut s);
-                    named.push((name.to_string(), s));
+                    named.push((name.to_string(), s.cleanup()));
                 }
             }
             // HS `process` tail: `removeRedundantCases ctxt [] snd`

--- a/crates/tamarin-theory/src/constraint/solver/proof_method.rs
+++ b/crates/tamarin-theory/src/constraint/solver/proof_method.rs
@@ -427,16 +427,7 @@ pub fn exec_proof_method(
                 };
             }
             simp_noop_stat(false);
-            // HS-faithful `cleanup` (ProofMethod.hs): EVERY
-            // proof method's cases pass through `map (fmap cleanup .
-            // fst)`, and `Simplify` goes through `process` — so its
-            // output is ALSO cleaned.
-            let cleanup = |s: &System| -> System {
-                let mut s2 = s.clone();
-                crate::constraint::solver::rename_precise::rename_precise_system(&mut s2);
-                s2.eq_store_mut().subst = tamarin_term::subst::Subst::from_list(Vec::new());
-                s2
-            };
+
             // HS-faithful filter: cases whose eq_store is false were
             // mzero'd by `contradictoryIf` during simplify; they don't
             // show up in HS's surviving Disj.  (Other contradiction
@@ -444,17 +435,13 @@ pub fn exec_proof_method(
             let cleaned: Vec<System> = case_systems
                 .into_iter()
                 .filter(|s| !s.eq_store.is_false())
-                .map(|mut s| {
+                .map(|s| {
                     // HS-faithful `cleanup` (ProofMethod.hs) applied in
                     // place: `case_systems` is owned here (from
                     // `simplify_system_with_fanout`'s into_iter), so we
                     // rename and clear the subst on the owned System
-                    // directly.  Value-identical to `cleanup(&s)`; that
-                    // closure only clones because its callers hand it a
-                    // `&System` (the borrowed `cleanup(sys)` site below).
-                    crate::constraint::solver::rename_precise::rename_precise_system(&mut s);
-                    s.eq_store_mut().subst = tamarin_term::subst::Subst::from_list(Vec::new());
-                    s
+                    // directly.
+                    s.cleanup()
                 })
                 .collect();
             // HS-faithful `removeRedundantCases ctxt [] snd`
@@ -488,7 +475,7 @@ pub fn exec_proof_method(
             if cleaned.is_empty() {
                 return Some(Vec::new());
             }
-            let cleaned_input = cleanup(sys);
+            let cleaned_input = sys.clone().cleanup();
             if cleaned.len() == 1 {
                 // Single-case path: HS's `Simplify` arm (ProofMethod.hs)
                 // checks whether the simplified system equals the cleaned
@@ -561,16 +548,7 @@ pub fn exec_proof_method(
                 // `cleanup` (ProofMethod.hs):
                 //   cleanup s = L.set sSubst emptySubst
                 //                       (renamePrecise s)
-                let mut out: Vec<System> = Vec::with_capacity(raw_systems.len());
-                for mut s in raw_systems {
-                    crate::constraint::solver::rename_precise::rename_precise_system(&mut s);
-                    if !s.eq_store.is_false() {
-                        s.invalidate_max_var_idx_cache();
-                        s.eq_store_mut().subst = tamarin_term::subst::Subst::from_list(Vec::new());
-                    }
-                    out.push(s);
-                }
-                out
+                raw_systems.into_iter().map(|s| s.cleanup()).collect()
             };
             // Filter cases the same way Haskell's `runReduction` does:
             // when a CR-rule called `contradictoryIf` during simplify

--- a/crates/tamarin-theory/src/constraint/system.rs
+++ b/crates/tamarin-theory/src/constraint/system.rs
@@ -1746,10 +1746,18 @@ impl System {
 
     /// Port of Haskell's `cleanup` (`ProofMethod.hs:310-311`):
     ///
-    /// Resets the systems variable indices and clears the substitution.
+    /// Resets the system's variable indices and clears the substitution.
     pub fn cleanup(mut self) -> Self {
         crate::constraint::solver::rename_precise::rename_precise_system(&mut self);
         self.eq_store_mut().subst = tamarin_term::subst::Subst::from_list(Vec::new());
+        // The subst is inside `bounds_max`'s walk (dom + range,
+        // reduction.rs `bounds_max_rest`), so clearing it can LOWER the
+        // max free-var idx — while `rename_precise_system` invalidates
+        // the cache only when some var was actually remapped.  After an
+        // all-identity rename a pre-populated cache would survive with
+        // the pre-clear max (stale-high ⇒ fresh idxs minted above HS's).
+        // Invalidate so the next `bounds_max` recomputes post-clear.
+        self.invalidate_max_var_idx_cache();
         self
     }
 }
@@ -2302,6 +2310,31 @@ mod tests {
         let c0 = s.content_stamp.get();
         s.set_last_atom(None);
         assert_ne!(s.content_stamp.get(), c0);
+    }
+
+    #[test]
+    fn cleanup_invalidates_max_var_idx_cache() {
+        use crate::constraint::solver::reduction::{bounds_max, bounds_max_uncached};
+        use tamarin_term::term::Term;
+        use tamarin_term::vterm::Lit;
+
+        // Per-name idxs dense from 0 make `rename_precise_system` the
+        // identity (no remap ⇒ no invalidation from the rename itself),
+        // while the subst holds the global max idx: `x.1` occurs nowhere
+        // outside the subst range, so `cleanup`'s subst-clear lowers the
+        // true max from 1 to 0.
+        let mut s = System::empty();
+        s.set_last_atom(Some(LVar::new("i", LSort::Node, 0)));
+        s.eq_store_mut().subst = tamarin_term::subst::Subst::from_list([(
+            LVar::new("x", LSort::Msg, 0),
+            Term::Lit(Lit::Var(LVar::new("x", LSort::Msg, 1))),
+        )]);
+        // Populate the cache with the pre-cleanup max (held by the subst).
+        assert_eq!(bounds_max(&s), 1);
+        let s = s.cleanup();
+        assert_eq!(bounds_max_uncached(&s), 0);
+        // The cached read must match — a stale cache would return 1 here.
+        assert_eq!(bounds_max(&s), 0);
     }
 
     #[test]

--- a/crates/tamarin-theory/src/constraint/system.rs
+++ b/crates/tamarin-theory/src/constraint/system.rs
@@ -1743,6 +1743,15 @@ impl System {
         self.solved_formulas.is_empty()
             && !crate::guarded::stores_contains(&self.formulas, &crate::guarded::gfalse())
     }
+
+    /// Port of Haskell's `cleanup` (`ProofMethod.hs:310-311`):
+    ///
+    /// Resets the systems variable indices and clears the substitution.
+    pub fn cleanup(mut self) -> Self {
+        crate::constraint::solver::rename_precise::rename_precise_system(&mut self);
+        self.eq_store_mut().subst = tamarin_term::subst::Subst::from_list(Vec::new());
+        self
+    }
 }
 
 // =============================================================================


### PR DESCRIPTION
Deduplicating the cleanup logic used in `exec_proof_method` by turning it into a function on `System`.

The original code was using `s.invalidate_max_var_idx_cache()` in one place, but this is handled by `rename_precise_system` on the System anyway.

I'd like to set the cache again in `rename_precise_system`, which it currently does not seem to be doing. It should set the cache to the `max_var_idx` in the computed renaming.

However, since the testing script does not seem to be working for me locally, I have refrained from doing so for now.