### PR TITLE
Fix Issue with Nat-sorted structural_match against App-shaped terms

### DIFF
--- a/crates/tamarin-theory/src/constraint/solver/simplify.rs
+++ b/crates/tamarin-theory/src/constraint/solver/simplify.rs
@@ -2186,21 +2186,6 @@ fn structural_match(
             (LSort::Msg, LSort::Pub | LSort::Fresh | LSort::Nat)
         )
     }
-    fn term_lsort(t: &tamarin_term::lterm::LNTerm) -> LSort {
-        match t {
-            Term::Lit(Lit::Var(v)) => v.sort,
-            Term::Lit(Lit::Con(n)) => match n.tag {
-                tamarin_term::lterm::NameTag::Pub => LSort::Pub,
-                tamarin_term::lterm::NameTag::Fresh => LSort::Fresh,
-                tamarin_term::lterm::NameTag::Nat => LSort::Nat,
-                tamarin_term::lterm::NameTag::Node => LSort::Node,
-            },
-            Term::App(FunSym::NoEq(_), _)
-            | Term::App(FunSym::C(_), _)
-            | Term::App(FunSym::Ac(_), _)
-            | Term::App(FunSym::List, _) => LSort::Msg,
-        }
-    }
     // Pairwise left-to-right recursion shared by the `NoEq` and `List`
     // arms (HS `sequence_ . zipWith match`): equal arity required, first
     // non-`Matched` outcome wins.
@@ -2232,7 +2217,7 @@ fn structural_match(
         // (System.hs:1111-1145, see line 1122 + Guarded.hs:741-805) the universal's bound
         // vars remain `Var`; free system vars become `SkConst`.
         (Term::Lit(Lit::Var(pv)), _) if pattern_vars.contains(&(pv.name.to_string(), pv.idx)) => {
-            let subj_sort = term_lsort(subj);
+            let subj_sort = tamarin_term::lterm::sort_of_lnterm(subj);
             if !sort_compatible(pv.sort, subj_sort) {
                 return StructMatch::NoMatcher;
             }

--- a/crates/tamarin-theory/tests/fixtures/nat_sort_regression.spthy
+++ b/crates/tamarin-theory/tests/fixtures/nat_sort_regression.spthy
@@ -1,0 +1,230 @@
+/*
+  Regression theory for a Rust-port bug in `structural_match`
+  (crates/tamarin-theory/src/constraint/solver/simplify.rs):
+  `insert_implied_formulas_pass` matches a `[reuse]` lemma's antecedent
+  against concrete action facts to derive its consequence. A local
+  `term_lsort` helper classified every function-application term as
+  sort `Msg`, including natural-number literals like `tone()` (the
+  internal `App` form of `%1`), so a Nat-sorted pattern variable
+  (here `%idx`) failed to match a concrete `tone()` argument even
+  though it should. That silently dropped the reuse lemma's implied
+  `HonestSignatureKey` fact whenever the triggering action came from
+  the intruder directly forging a signature rather than from an
+  already-posted board entry.
+
+  Trimmed from a larger election-trustee-board protocol theory down to
+  the minimum needed to reproduce the mechanism. Both tamarin-prover
+  and a fixed tamarin-rs prove `CanForgeAndPost` via an 8-step proof
+  that solves `HonestSignatureKey` as an explicit intermediate step;
+  the pre-fix Rust port instead finds a 7-step proof that skips it
+  entirely (the goal was never created), which is byte-different
+  even though the verdict is unchanged.
+*/
+
+theory election_key_generation_nat_sort_regression
+
+begin
+
+builtins:
+  asymmetric-encryption, natural-numbers, multiset
+
+functions:
+  sign/3, e1_sig/1 [private], e3_sig/1 [private], true/0, false/0
+
+equations:
+  e1_sig(sign(x, y, z)) = x,
+  e3_sig(sign(x, y, z)) = z
+
+/*
+  This restriction states that an honestly generated key, an honestly
+  generated signature, and the correct message must verify as true.
+ */
+restriction SignatureCorrectness:
+  "
+    All sig m pk #t1 #t2.
+            HonestSignatureKey(pk)@t1
+          &
+            SignatureVerified(sig, m, pk, m, pk, false)@t2
+      ==>
+          F
+  "
+
+/*
+  This restriction states that if a signature verification succeeds
+  against an honest public key, then the signature must have been
+  honestly produced.
+ */
+restriction SignatureUnforgeability:
+  "
+    All sig sigm sigpk verm verpk #t1 #t2.
+            HonestSignatureKey(verpk)@t1
+          &
+            SignatureVerified(sig, sigm, sigpk, verm, verpk, true)@t2
+      ==>
+            sigm = verm
+          &
+            sigpk = verpk
+  "
+
+/*
+  This restriction states that the signature verification procedure
+  is deterministic.
+ */
+restriction SignatureDeterminism:
+  "
+    All sig sigm sigpk verm verpk res1 res2 #t1 #t2.
+            SignatureVerified(sig, sigm, sigpk, verm, verpk, res1)@t1
+          &
+            SignatureVerified(sig, sigm, sigpk, verm, verpk, res2)@t2
+      ==>
+          res1 = res2
+  "
+
+/*
+  Restriction that a rule specified by a single value can only be
+  executed once in the entire trace.
+ */
+restriction Unique:
+  "All x #i #j. Unique(x)@i & Unique(x)@j ==> #i = #j"
+
+/*
+  This rule waits for a message to be submitted by a trustee,
+  checks its signature, and posts it to the trustee board.
+ */
+rule TrusteeBoard_TAS_ReceiveTrusteeMessage [role="TAS"]:
+    [ TAS_State_ReceiveTrusteeMessage(%idx),
+      Trustee_Message_Submit(trustee, msg, sig),
+      !Trustee_Public_Keys(trustee, pk_sign, pk_encrypt_unused) ]
+  --[ Unique(<'BBEntry', %idx>),
+      TAS_BBEntry_Trace(trustee, fst(msg), msg, sig, %idx),
+      SignatureVerified(sig, e1_sig(sig), pk(e3_sig(sig)),
+                        msg, pk_sign, true) /* valid signature */ ]->
+    [ !TAS_BBEntry(trustee, msg, sig, %idx),
+      TAS_State_ReceiveTrusteeMessage(%idx %+ %1) ]
+
+/*
+  This rule allows the adversary to (attempt to) submit a message
+  to the trustee board.
+ */
+rule TrusteeBoard_Inject_Arbitrary_Trustee_Message:
+    [ In(<trustee, msg, sig>),
+      !Trustee_Public_Keys(trustee, pk_sign, pk_encrypt_unused) ]
+  --[ InjectTrusteeMsg(trustee, msg, sig),
+      SignatureVerified(sig, e1_sig(sig), pk(e3_sig(sig)),
+                        msg, pk_sign, true) /* valid signature */ ]->
+    [ Trustee_Message_Submit(trustee, msg, sig) ]
+
+/*
+  This rule allows the adversary to see any trustee board message
+  that has been posted.
+ */
+rule TrusteeBoard_Reveal_BB_Message:
+    [ !TAS_BBEntry(t, m, s, %i) ]
+  --[ RevealBBMsg(t, m, s, %i) ]->
+    [ Out(<m, s>) /* t and %i are already known to the adversary */ ]
+
+/*
+  This rule updates a trustee's local copy of the trustee board. It only
+  fires if the next message it needs from the TAS is a legal addition to
+  the trustee board.
+ */
+rule TrusteeBoard_Trustee_Update [role="Trustee"]:
+    [ Trustee_State_ReceiveBBMessage(trustee, %idx),
+      !TAS_BBEntry(sender, msg, sig, %idx) ]
+  --[ Trustee_BBEntry_Trace(trustee, sender, fst(msg), msg, sig, %idx),
+      OUT_TRUSTEE_BBENTRY(trustee, sender, msg, sig, %idx) ]->
+    [ !Trustee_BBEntry(trustee, sender, msg, sig, %idx),
+      Trustee_State_ReceiveBBMessage(trustee, %idx %+ %1) ]
+
+/*
+  This rule enters an error state and stops updating a trustee's local
+  copy of the trustee board if an invalid message is detected on the
+  global trustee board.
+ */
+rule TrusteeBoard_Trustee_Error [role="Trustee"]:
+    [ Trustee_State_ReceiveBBMessage(trustee, %idx),
+      !TAS_BBEntry(sender, msg, sig, %idx) ]
+  --[ Trustee_BBError_Trace(trustee, sender, fst(msg), msg, sig, %idx),
+      Trustee_Trace_Error(trustee, <'invalid trustee board message', sender, msg>) ]->
+    [ !Terminal_Error(trustee) /* no further trustee execution */ ]
+
+/*
+  The initial configuration of the trustees and the trustee
+  administration server. Abstracted to a single trustee for this
+  regression theory (the original has three; one is enough to
+  reproduce the bug).
+ */
+rule Mock_TrusteeElectionSetup [role="Mock"]:
+    [ Fr(~sk_sign_tas),
+      Fr(~sk_sign_trustee1),
+      Fr(~sk_encrypt_trustee1) ]
+  --[ Unique('Mock_TrusteeElectionSetup'),
+      HonestSignatureKey(pk(~sk_sign_tas)),
+      TAS_Trustee_Trace('Trustee1', pk(~sk_sign_trustee1), pk(~sk_encrypt_trustee1)),
+      HonestSignatureKey(pk(~sk_sign_trustee1)) ]->
+    [ !TAS_Secret_Signing_Key(~sk_sign_tas),
+      !TAS_Public_Signing_Key(pk(~sk_sign_tas)),
+      !Trustee('Trustee1'),
+      !Trustee_Secret_Keys('Trustee1', ~sk_sign_trustee1, ~sk_encrypt_trustee1),
+      !Trustee_Public_Keys('Trustee1', pk(~sk_sign_trustee1), pk(~sk_encrypt_trustee1)),
+      TAS_State_BeginTrusteeThresholdKeygen(),
+      Out(pk(~sk_sign_trustee1)),
+      Out(pk(~sk_encrypt_trustee1)),
+      Out(pk(~sk_sign_tas)) ]
+
+/*
+  This rule initializes the counter for trustee board messages.
+ */
+rule ElectionKeyGeneration_TAS_Init [role="TAS"]:
+    [ TAS_State_BeginTrusteeThresholdKeygen(),
+      !TAS_Secret_Signing_Key(sk_sign) ]
+  --[ TAS_ElectionKeyGeneration_Init_Trace() ]->
+    [ Trustee_State_ReceiveBBMessage('Trustee1', %1),
+      TAS_State_ReceiveTrusteeMessage(%1) ]
+
+/*
+  This rule reveals a trustee's private keys to the adversary.
+ */
+rule ElectionKeyGeneration_Reveal_Trustee_Keys:
+    [ !Trustee_Secret_Keys(trustee, sk_sign, sk_encrypt) ]
+  --[ Unique(<'RevealTrusteeKeys', trustee>),
+      RevealTrusteeKeys(trustee) ]->
+    [ Out(<trustee, sk_sign, sk_encrypt>) ]
+
+/*
+  This lemma states that every entry on the TAS trustee board, other
+  than the root message, is from a registered trustee and has a
+  valid signature.  Its consequence (`HonestSignatureKey`) is what the
+  bug silently failed to derive.
+ */
+lemma Safety_ElectionKeyGeneration_TAS_BB_Message_Validity [reuse]:
+  "
+    All tr mt msg sig %idx #i.
+            TAS_BBEntry_Trace(tr, mt, msg, sig, %idx)@i
+      ==>
+          (Ex pk_sign pk_encrypt param sk #j #k.
+              TAS_Trustee_Trace(tr, pk_sign, pk_encrypt)@j
+            &
+              HonestSignatureKey(pk_sign)@k
+            &
+              pk(sk) = pk_sign
+            &
+              sig = sign(msg, param, sk)
+          )
+  "
+
+/*
+  Exists-trace witness requiring the adversary to construct a signed
+  message directly (`case c_sign`) using a trustee's revealed signing
+  key, post it to the TAS trustee board, and have the trustee detect it
+  as invalid (since it was never legitimately sent). Reaching `SOLVED`
+  needs the `HonestSignatureKey` fact the reuse lemma above must supply
+  in order to justify the trustee board entry's signature at all.
+ */
+lemma CanForgeAndPost:
+  exists-trace
+  "
+    Ex t e #i. Trustee_Trace_Error(t, e)@i
+  "
+
+end

--- a/crates/tamarin-theory/tests/oracle_solver.rs
+++ b/crates/tamarin-theory/tests/oracle_solver.rs
@@ -2605,3 +2605,69 @@ fn fixture_disj_lemma_round_trip() {
     // pretty-printed parse-only form should preserve the `|`.
     assert!(out.contains('|') || out.contains('∨'));
 }
+
+/// Regression: `insert_implied_formulas_pass` must derive a `[reuse]`
+/// lemma's implied consequence even when the triggering action's
+/// argument is a Nat-sorted `App` term (e.g. `tone()`, the internal
+/// form of `%1`) rather than a `Lit`. A prior bug in `structural_match`
+/// classified every `App` as sort `Msg`, so a Nat-sorted pattern
+/// variable never matched — silently dropping the reuse lemma's
+/// `HonestSignatureKey` consequence whenever no sibling action offered
+/// a free-variable fallback. The verdict alone doesn't catch this: the
+/// buggy port still finds `Solved` via a shorter path that skips
+/// `HonestSignatureKey` entirely. So this checks the proof tree
+/// explicitly contains a `HonestSignatureKey` step.
+#[test]
+fn fixture_nat_sort_reuse_lemma_derives_implied_fact() {
+    use tamarin_theory::constraint::constraints::Goal;
+    use tamarin_theory::constraint::solver::proof_method::ProofMethod;
+    use tamarin_theory::constraint::solver::search::{NodeStatus, ProofNode};
+    use tamarin_theory::prove::prove_lemma;
+
+    let mp = match maude_path() {
+        Some(p) => p,
+        None => return,
+    };
+    let path = fixtures_dir().join("nat_sort_regression.spthy");
+    let src = std::fs::read_to_string(&path).expect("read fixture");
+    let theory = parse_theory(&src, &[]).expect("parse");
+    let elab = tamarin_theory::elaborate::elaborate(&theory).expect("elaborate");
+    let h = tamarin_term::maude_proc::MaudeHandle::start(&mp, elab.signature.maude_sig.clone())
+        .unwrap();
+    let root = prove_lemma(&theory, "CanForgeAndPost", h, 500).expect("prove_lemma");
+    assert_eq!(root.status, NodeStatus::Solved, "expected a witness trace");
+
+    fn contains_honest_signature_key(n: &ProofNode) -> bool {
+        if let ProofMethod::SolveGoal(Goal::Action(_, fa)) = &n.method {
+            if tamarin_theory::fact::fact_tag_name(&fa.tag) == "HonestSignatureKey" {
+                return true;
+            }
+        }
+        n.children.values().any(contains_honest_signature_key)
+    }
+    assert!(
+        contains_honest_signature_key(&root),
+        "proof must solve HonestSignatureKey as an explicit step; \
+         the reuse lemma's implied fact was silently dropped"
+    );
+
+    // Confirm tamarin agrees, when the binary is available.
+    if !tamarin_available() {
+        return;
+    }
+    let proved = run_tamarin_prove(&path).expect("tamarin");
+    let summary = extract_summary(&proved).expect("summary");
+    let line = summary
+        .lines()
+        .find(|l| l.contains("CanForgeAndPost ("))
+        .expect("summary line for CanForgeAndPost");
+    assert!(
+        line.contains("verified"),
+        "tamarin should verify CanForgeAndPost; got line:\n{}",
+        line
+    );
+    assert!(
+        proved.contains("HonestSignatureKey( pk(~sk_sign_trustee1) ) @ #k"),
+        "tamarin's own proof must solve HonestSignatureKey explicitly"
+    );
+}


### PR DESCRIPTION
I decided to investigate #4 myself (with significant LLM assistance), and found an issue with structural_match's sort check that made a Nat-sorted pattern variable (e.g. a [reuse] lemma's %idx) fail to match a concrete tone()-shaped action argument; this was the cause of the missing goals in the Rust port for the theory I attached to #4.

This PR changes the code to use the existing `sort_of_lnterm`, which already special-cases NatPlus and the nullary tone constructor as LSort::Nat, instead of the local, incomplete `term_lsort` it was using. It also adds a regression fixture, trimmed from a larger theory that had exhibited issues, plus a test that checks that the proof tree explicitly solves the goal that was previously missing.

Closes #4 (if merged).