### PR TITLE
Fix pretty printing of restrictions with attributes

### DIFF
--- a/crates/tamarin-theory/src/close_rule.rs
+++ b/crates/tamarin-theory/src/close_rule.rs
@@ -442,10 +442,8 @@ fn deduction_restrictions(with_only_once_d: bool) -> Vec<Guarded> {
 /// order, first occurrence wins.  Fixes the lemma's data-binder order.
 fn collect_var_specs(t: &p::Term, out: &mut Vec<p::VarSpec>) {
     match t {
-        p::Term::Var(v) => {
-            if !out.contains(v) {
-                out.push(v.clone());
-            }
+        p::Term::Var(v) if !out.contains(v) => {
+            out.push(v.clone());
         }
         p::Term::App(_, args) | p::Term::Pair(args) => {
             for a in args {

--- a/crates/tamarin-theory/src/pretty_theory.rs
+++ b/crates/tamarin-theory/src/pretty_theory.rs
@@ -3154,8 +3154,6 @@ fn render_parsed_restriction(
     } else {
         out.push_str(&r.name);
     }
-
-    out.push(' ');
     render_restriction_attributes(&r.attributes, &mut out);
 
     out.push_str(":\n");
@@ -3188,7 +3186,7 @@ fn render_restriction_attributes(attrs: &[p::RestrictionAttr], out: &mut String)
     if attrs.is_empty() {
         return;
     }
-
+    out.push(' ');
     out.push('[');
     let attr_strs: Vec<&str> = attrs
         .iter()

--- a/crates/tamarin-theory/src/pretty_theory.rs
+++ b/crates/tamarin-theory/src/pretty_theory.rs
@@ -820,7 +820,6 @@ fn render_open_restriction(
     out.push_str(&keyword_("restriction").render());
     out.push(' ');
     out.push_str(&r.name);
-    out.push(' ');
     render_restriction_attributes(&r.attributes, &mut out);
     out.push_str(":\n");
     out.push_str(&pf::formula_doublequoted_nested(&original, 2));

--- a/crates/tamarin-theory/src/pretty_theory.rs
+++ b/crates/tamarin-theory/src/pretty_theory.rs
@@ -816,9 +816,23 @@ fn render_open_restriction(
         ));
     use crate::pretty_hpj::{keyword_, line_comment_};
     let mut out = String::new();
+
     out.push_str(&keyword_("restriction").render());
     out.push(' ');
     out.push_str(&r.name);
+    if !r.attributes.is_empty() {
+        out.push_str(" [");
+        let attrs: Vec<&str> = r
+            .attributes
+            .iter()
+            .map(|a| match a {
+                p::RestrictionAttr::LeftRestriction => "left",
+                p::RestrictionAttr::RightRestriction => "right",
+            })
+            .collect();
+        out.push_str(&attrs.join(", "));
+        out.push(']');
+    }
     out.push_str(":\n");
     out.push_str(&pf::formula_doublequoted_nested(&original, 2));
     if is_safety_formula(&original) {

--- a/crates/tamarin-theory/src/pretty_theory.rs
+++ b/crates/tamarin-theory/src/pretty_theory.rs
@@ -3187,7 +3187,7 @@ fn render_restriction_attributes(attrs: &[p::RestrictionAttr], out: &mut String)
         return;
     }
 
-    out.push_str("[");
+    out.push('[');
     let attr_strs: Vec<&str> = attrs
         .iter()
         .map(|a| match a {

--- a/crates/tamarin-theory/src/pretty_theory.rs
+++ b/crates/tamarin-theory/src/pretty_theory.rs
@@ -820,19 +820,7 @@ fn render_open_restriction(
     out.push_str(&keyword_("restriction").render());
     out.push(' ');
     out.push_str(&r.name);
-    if !r.attributes.is_empty() {
-        out.push_str(" [");
-        let attrs: Vec<&str> = r
-            .attributes
-            .iter()
-            .map(|a| match a {
-                p::RestrictionAttr::LeftRestriction => "left",
-                p::RestrictionAttr::RightRestriction => "right",
-            })
-            .collect();
-        out.push_str(&attrs.join(", "));
-        out.push(']');
-    }
+    render_restriction_attributes(&r.attributes, &mut out);
     out.push_str(":\n");
     out.push_str(&pf::formula_doublequoted_nested(&original, 2));
     if is_safety_formula(&original) {
@@ -3165,6 +3153,9 @@ fn render_parsed_restriction(
     } else {
         out.push_str(&r.name);
     }
+
+    render_restriction_attributes(&r.attributes, &mut out);
+
     out.push_str(":\n");
     // Top-level display: original formula (macro form) — `fromMaybe expandedFormula ogFormula`.
     // Since ogFormula = Just original, this always shows `r.formula` (macro form).
@@ -3188,6 +3179,24 @@ fn render_parsed_restriction(
     out.push_str("\n  */");
     out.push_str(&hl_close(Hl::Comment));
     out
+}
+
+/// Render the restriction attributes, i.e., `left` and/or `right`
+fn render_restriction_attributes(attrs: &[p::RestrictionAttr], out: &mut String) {
+    if attrs.is_empty() {
+        return;
+    }
+
+    out.push_str("[");
+    let attr_strs: Vec<&str> = attrs
+        .iter()
+        .map(|a| match a {
+            p::RestrictionAttr::LeftRestriction => "left",
+            p::RestrictionAttr::RightRestriction => "right",
+        })
+        .collect();
+    out.push_str(&attr_strs.join(", "));
+    out.push(']');
 }
 
 /// Render one predicate item, mirroring HS `prettyPredicate`

--- a/crates/tamarin-theory/src/pretty_theory.rs
+++ b/crates/tamarin-theory/src/pretty_theory.rs
@@ -820,6 +820,7 @@ fn render_open_restriction(
     out.push_str(&keyword_("restriction").render());
     out.push(' ');
     out.push_str(&r.name);
+    out.push(' ');
     render_restriction_attributes(&r.attributes, &mut out);
     out.push_str(":\n");
     out.push_str(&pf::formula_doublequoted_nested(&original, 2));
@@ -3154,6 +3155,7 @@ fn render_parsed_restriction(
         out.push_str(&r.name);
     }
 
+    out.push(' ');
     render_restriction_attributes(&r.attributes, &mut out);
 
     out.push_str(":\n");


### PR DESCRIPTION
Restrictions can be annotated with the `left` and `right` attribute but their pretty printing ignored these attributes.